### PR TITLE
TDD: Remove SC2312 suppression in security exclusion loop

### DIFF
--- a/.claude/hooks/multi_linter.sh
+++ b/.claude/hooks/multi_linter.sh
@@ -310,13 +310,14 @@ is_excluded_from_security_linters() {
   fi
 
   local exclusion
-  # shellcheck disable=SC2312
+  local exclusions
+  exclusions=$(get_security_linter_exclusions || true)
   while IFS= read -r exclusion; do
     [[ -z "${exclusion}" ]] && continue
     if [[ "${fp}" == ${exclusion}* ]]; then
       return 0
     fi
-  done < <(get_security_linter_exclusions || true)
+  done <<<"${exclusions}"
   return 1
 }
 

--- a/.claude/hooks/test/test_security_exclusions_compat.sh
+++ b/.claude/hooks/test/test_security_exclusions_compat.sh
@@ -193,6 +193,40 @@ assert "test3_vulture" "grep -q 'VULTURE' '${tmp_dir}/test3.stderr'" \
   "vulture finding still appears without exclusions" \
   "vulture finding missing without exclusions"
 
+# ============================================================================
+# Test 4: exclusion function should be shellcheck-clean without SC2312 suppress
+# ============================================================================
+printf "\n--- test4: exclusion loop has no SC2312 suppression ---\n"
+
+func_block="${tmp_dir}/test4_func_block.txt"
+awk '/^is_excluded_from_security_linters\(\)/,/^}/ {print}' \
+  "${hook_dir}/multi_linter.sh" >"${func_block}"
+
+assert "test4_no_sc2312" "! grep -q 'shellcheck disable=SC2312' '${func_block}'" \
+  "is_excluded_from_security_linters has no SC2312 suppression" \
+  "is_excluded_from_security_linters still has SC2312 suppression"
+
+# ============================================================================
+# Test 5: malformed config must not crash set -e exclusion path
+# ============================================================================
+printf "\n--- test5: malformed config does not crash exclusion path ---\n"
+
+test5_dir="${tmp_dir}/test5"
+# Intentionally malformed JSON to force get_security_linter_exclusions parse fail.
+setup_project_dir "${test5_dir}" '{
+  "phases": { "subprocess_delegation": false },
+  "security_linter_exclusions": ["tests/"]
+'
+run_case "${test5_dir}" "test5"
+
+assert "test5_exit" "grep -qx '2' '${tmp_dir}/test5.exit'" \
+  "malformed config path still returns deterministic violations (no hook crash)" \
+  "malformed config path did not return expected exit 2"
+
+assert "test5_b105" "grep -q 'B105' '${tmp_dir}/test5.stderr'" \
+  "malformed config path still executes security linters" \
+  "malformed config path did not execute security linter checks"
+
 printf "\n=== Summary ===\n"
 printf "Passed: %d\nFailed: %d\n" "${passed}" "${failed}"
 [[ "${failed}" -gt 0 ]] && exit 1


### PR DESCRIPTION
## Summary
- Refactors `is_excluded_from_security_linters` in `.claude/hooks/multi_linter.sh` to remove `# shellcheck disable=SC2312`.
- Keeps behavior stable by switching to a ShellCheck-clean here-string loop fed by `exclusions=$(get_security_linter_exclusions || true)`.
- Adds TDD coverage in `.claude/hooks/test/test_security_exclusions_compat.sh` to prevent regression.

## TDD Flow
1. RED: Added a failing assertion that the function block must not contain SC2312 suppression.
2. GREEN: Refactored loop implementation to pass the new test while preserving existing exclusion behavior.
3. REFACTOR: Kept the implementation minimal and validated full hook self-tests.

## Validation
- `bash .claude/tests/hooks/test_security_exclusions_compat.sh` -> 10 passed, 0 failed
- `shellcheck .claude/hooks/multi_linter.sh` -> clean
- `bash .claude/hooks/test_hook.sh --self-test` -> 160 passed, 0 failed
- `PLANKTON_STRICT_ALLOW_PROTECTED=1 ./scripts/pre_commit_plankton_strict.sh .claude/hooks/multi_linter.sh .claude/hooks/test/test_security_exclusions_compat.sh` -> clean

## Risk
- Low. This change is isolated to exclusion-list iteration logic and is guarded by compatibility tests plus full hook self-tests.