### PR TITLE
Improve setup wizard with guided dependency installation

### DIFF
--- a/.claude/hooks/multi_linter.sh
+++ b/.claude/hooks/multi_linter.sh
@@ -108,6 +108,24 @@ get_security_linter_exclusions() {
   echo "${CONFIG_JSON}" | jaq -r ".security_linter_exclusions // .exclusions // ${defaults} | .[]" 2>/dev/null
 }
 
+get_bandit_config_file() {
+  local config_file="${CLAUDE_PROJECT_DIR:-.}/pyproject.toml"
+  if [[ -f "${config_file}" ]]; then
+    printf '%s\n' "${config_file}"
+  fi
+}
+
+run_bandit_json() {
+  local target_file="$1"
+  local bandit_config
+  bandit_config=$(get_bandit_config_file)
+  if [[ -n "${bandit_config}" ]]; then
+    uv run bandit -c "${bandit_config}" -f json -q "${target_file}" 2>/dev/null || true
+  else
+    uv run bandit -f json -q "${target_file}" 2>/dev/null || true
+  fi
+}
+
 # Detect and reject old flat config format
 check_config_migration() {
   local has_old_timeout has_old_model_selection
@@ -780,7 +798,7 @@ rerun_phase2() {
       # bandit violations
       if command -v uv >/dev/null 2>&1; then
         local bandit_out
-        bandit_out=$(uv run bandit -f json -q "${fp}" 2>/dev/null) || true
+        bandit_out=$(run_bandit_json "${fp}")
         local bandit_count
         bandit_count=$(echo "${bandit_out}" | jaq '.results | length // 0' 2>/dev/null | head -n1 || echo "0")
         count=$((count + bandit_count))
@@ -1313,7 +1331,7 @@ case "${file_path}" in
     is_excluded_from_security_linters "${file_path}" && _bandit_rc=0 || _bandit_rc=$?
     if [[ ${_bandit_rc} -eq 0 ]]; then _excluded_bandit=true; fi
     if ! "${_excluded_bandit}" && command -v uv >/dev/null 2>&1; then
-      bandit_output=$(uv run bandit -f json -q "${file_path}" 2>/dev/null) || true
+      bandit_output=$(run_bandit_json "${file_path}")
       bandit_results=$(echo "${bandit_output}" | jaq '.results // []' 2>/dev/null) || bandit_results="[]"
       if [[ "${bandit_results}" != "[]" ]] && [[ "${bandit_results}" != "null" ]]; then
         # Convert bandit JSON to standard format

--- a/.claude/hooks/test/test_security_exclusions_compat.sh
+++ b/.claude/hooks/test/test_security_exclusions_compat.sh
@@ -77,6 +77,40 @@ case "${cmd}" in
     printf '%s:2: unused variable %s\n' "${target}" "'password'"
     ;;
   bandit)
+    bandit_config=""
+    bandit_target=""
+    while [[ $# -gt 0 ]]; do
+      case "${1}" in
+        -c|--configfile)
+          shift || true
+          bandit_config="${1:-}"
+          ;;
+        -f|--format)
+          shift || true
+          ;;
+        -q|--quiet)
+          ;;
+        -*)
+          ;;
+        *)
+          bandit_target="${1}"
+          ;;
+      esac
+      shift || true
+    done
+
+    if [[ -n "${bandit_config}" ]] \
+      && [[ -f "${bandit_config}" ]] \
+      && grep -Eq 'exclude_dirs\s*=\s*\[[^]]*"tests"' "${bandit_config}" \
+      && [[ "${bandit_target}" == *"/tests/"* ]]; then
+      cat <<'BANDIT_EMPTY_JSON'
+{
+  "results": []
+}
+BANDIT_EMPTY_JSON
+      exit 0
+    fi
+
     cat <<'BANDIT_JSON'
 {
   "results": [
@@ -226,6 +260,35 @@ assert "test5_exit" "grep -qx '2' '${tmp_dir}/test5.exit'" \
 assert "test5_b105" "grep -q 'B105' '${tmp_dir}/test5.stderr'" \
   "malformed config path still executes security linters" \
   "malformed config path did not execute security linter checks"
+
+# ============================================================================
+# Test 6: pyproject bandit exclude_dirs is honored for direct-file scans
+# ============================================================================
+printf "\n--- test6: pyproject bandit excludes tests/ for direct file scans ---\n"
+
+test6_dir="${tmp_dir}/test6"
+setup_project_dir "${test6_dir}" '{
+  "phases": { "subprocess_delegation": false },
+  "security_linter_exclusions": []
+}'
+cat >"${test6_dir}/pyproject.toml" <<'PYPROJECT_EOF'
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = []
+PYPROJECT_EOF
+run_case "${test6_dir}" "test6"
+
+assert "test6_exit" "grep -qx '2' '${tmp_dir}/test6.exit'" \
+  "vulture still reports while bandit excludes tests via pyproject" \
+  "unexpected exit code for pyproject bandit exclusion case"
+
+assert "test6_no_b105" "! grep -q 'B105' '${tmp_dir}/test6.stderr'" \
+  "bandit finding suppressed via pyproject exclude_dirs" \
+  "bandit finding still present despite pyproject exclude_dirs"
+
+assert "test6_vulture_present" "grep -q 'VULTURE' '${tmp_dir}/test6.stderr'" \
+  "vulture finding still appears (bandit-only exclusion behavior)" \
+  "vulture finding unexpectedly missing in pyproject exclusion case"
 
 printf "\n=== Summary ===\n"
 printf "Passed: %d\nFailed: %d\n" "${passed}" "${failed}"

--- a/README.md
+++ b/README.md
@@ -17,13 +17,19 @@ Write-time code quality enforcement for AI coding agents, built on Claude Code h
 ```bash
 git clone https://github.com/alexfazio/plankton.git
 cd plankton
-bash scripts/setup.sh   # installs all tools (macOS + Linux)
+python3 scripts/setup.py  # interactive setup wizard (recommended)
 claude                   # hooks activate automatically
 ```
 
 That's it. Plankton works by being the directory you run Claude Code from.
 The hooks in `.claude/hooks/` are picked up automatically — no install
 command, no plugin, no config. Clone, setup, claude.
+
+If you prefer non-interactive setup, use:
+
+```bash
+bash scripts/setup.sh   # non-interactive installer (macOS + Linux)
+```
 
 > [!NOTE]
 > **Windows** is not supported. Use
@@ -109,14 +115,27 @@ agent is blocked from proceeding until its output passes your checks —
 style, types, security, complexity — all enforced before commits and code
 review.
 
-1. **Run the Setup Wizard**:
+1. **Run the Interactive Setup Wizard**:
+
+   ```bash
+   python3 scripts/setup.py
+   ```
+
+   It auto-detects project languages, checks dependencies, and can
+   guide/install missing required tools (`jaq`, `ruff`, `uv`)
+   step-by-step.
+
+   If `uv` is already installed, this also works:
 
    ```bash
    uv run --no-project scripts/setup.py
    ```
 
-   This will auto-detect your project languages, check for
-   installed tools, and generate your configuration.
+   Non-interactive alternative:
+
+   ```bash
+   bash scripts/setup.sh
+   ```
 
 2. **Start a Claude Code session**. Hooks activate automatically.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -7,7 +7,7 @@ The easiest way to set up Plankton is using the **Interactive Setup Wizard**.
 Execute this command in your project root:
 
 ```bash
-uv run --no-project scripts/setup.py
+python3 scripts/setup.py
 ```
 
 The wizard will:
@@ -17,6 +17,18 @@ The wizard will:
 3. **Configure Hooks**: Interactively enable/disable language enforcement.
 4. **Finalize Environment**: Generate `.claude/hooks/config.json`
    and ensure hook scripts are executable.
+
+If `uv` is available, you can also run:
+
+```bash
+uv run --no-project scripts/setup.py
+```
+
+Prefer non-interactive setup? Use:
+
+```bash
+bash scripts/setup.sh
+```
 
 ## manual setup
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -13,16 +13,77 @@ the `.claude/hooks/config.json` configuration file.
 
 import json
 import os
+import shlex
 import shutil
 import subprocess  # noqa: S404  # nosec B404
 from copy import deepcopy
 from pathlib import Path
+from platform import system
+from types import SimpleNamespace
 from typing import Any, cast
 
-import typer
-from rich.console import Console
-from rich.panel import Panel
-from rich.prompt import Confirm
+typer: Any
+try:
+    import typer as _typer
+except ModuleNotFoundError:
+
+    class _FallbackExit(SystemExit):
+        def __init__(self, code: int = 0) -> None:
+            super().__init__(code)
+            self.code = code
+
+    class _FallbackTyper:
+        @staticmethod
+        def command():
+            def decorator(func):
+                return func
+
+            return decorator
+
+    typer = SimpleNamespace(Exit=_FallbackExit, Typer=_FallbackTyper)
+else:
+    typer = _typer
+
+
+def _strip_rich_markup(value: str) -> str:
+    """Best-effort stripping of rich markup for plain terminal fallback."""
+    cleaned = value
+    while "[" in cleaned and "]" in cleaned:
+        start = cleaned.find("[")
+        end = cleaned.find("]", start)
+        if end == -1:
+            break
+        cleaned = cleaned[:start] + cleaned[end + 1 :]
+    return cleaned
+
+
+try:
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.prompt import Confirm
+except ModuleNotFoundError:
+
+    class Console:  # noqa: D101
+        @staticmethod
+        def print(*args, **_kwargs) -> None:  # noqa: D102
+            text = " ".join(str(arg) for arg in args)
+            print(_strip_rich_markup(text))
+
+    class Panel:  # noqa: D101
+        @staticmethod
+        def fit(text: str, style: str = "") -> str:  # noqa: D102
+            del style
+            return text
+
+    class Confirm:  # noqa: D101
+        @staticmethod
+        def ask(prompt: str, default: bool = True) -> bool:  # noqa: D102
+            suffix = " [Y/n]: " if default else " [y/N]: "
+            answer = input(f"{_strip_rich_markup(prompt)}{suffix}").strip().lower()
+            if not answer:
+                return default
+            return answer in {"y", "yes"}
+
 
 console = Console()
 app = typer.Typer()
@@ -103,6 +164,7 @@ DEFAULT_CONFIG = {
 }
 
 SCAN_EXCLUDE_DIRS = {".git", ".venv", "node_modules", ".claude", "__pycache__"}
+LOCAL_BIN_DIR = Path.home() / ".local" / "bin"
 
 
 def _is_excluded_path(path: Path) -> bool:
@@ -173,9 +235,166 @@ def merge_config(existing_config: dict[str, Any], generated_config: dict[str, An
     return merged
 
 
+def _ensure_local_bin_on_path(show_hint: bool = False) -> None:
+    """Ensure ~/.local/bin is available in this process PATH."""
+    local_bin = str(LOCAL_BIN_DIR)
+    if LOCAL_BIN_DIR.exists() and local_bin not in os.environ.get("PATH", ""):
+        os.environ["PATH"] = f"{local_bin}:{os.environ.get('PATH', '')}"
+        if show_hint:
+            console.print("  [yellow]![/yellow] Added ~/.local/bin to PATH for this setup run.")
+            console.print("  [yellow]Persist:[/yellow] echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.zshrc")
+
+
+def _detect_linux_package_manager() -> str | None:
+    for manager in ("apt-get", "dnf", "yum", "pacman", "apk", "zypper"):
+        if shutil.which(manager):
+            return manager
+    return None
+
+
+def _with_sudo_if_needed(command: list[str]) -> list[str]:
+    if os.name == "posix" and hasattr(os, "geteuid") and os.geteuid() != 0 and shutil.which("sudo"):
+        return ["sudo", *command]
+    return command
+
+
+def _render_command(command: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
+
+
+def _run_install_command(command: list[str], description: str) -> bool:
+    console.print(f"  [cyan]→[/cyan] {description}")
+    console.print(f"    [dim]$ {_render_command(command)}[/dim]")
+    try:
+        # nosec B603 B607
+        result = subprocess.run(command, check=False)  # noqa: S603,S607
+    except FileNotFoundError:
+        console.print("    [red]✗[/red] Installer command not found in PATH.")
+        return False
+    if result.returncode != 0:
+        console.print(f"    [red]✗[/red] Installer exited with status {result.returncode}.")
+        return False
+    return True
+
+
+def _manual_install_hint(tool: str) -> str:
+    os_name = system().lower()
+    if tool in {"uv", "ruff"}:
+        return f"curl -LsSf https://astral.sh/{tool}/install.sh | sh"
+
+    if tool != "jaq":
+        return "bash scripts/setup.sh"
+
+    if os_name == "darwin":
+        return "brew install jaq"
+
+    if os_name != "linux":
+        return "bash scripts/setup.sh"
+
+    manager_to_command = {
+        "apt-get": "sudo apt-get install -y jaq",
+        "dnf": "sudo dnf install -y jaq",
+        "yum": "sudo yum install -y jaq",
+        "pacman": "sudo pacman -Sy --noconfirm jaq",
+        "apk": "sudo apk add jaq",
+        "zypper": "sudo zypper install -y jaq",
+    }
+    manager = _detect_linux_package_manager()
+    return manager_to_command.get(manager, "bash scripts/setup.sh")
+
+
+def _install_uv() -> bool:
+    command = ["sh", "-c", "curl -LsSf https://astral.sh/uv/install.sh | sh"]
+    if not _run_install_command(command, "Installing uv via official installer"):
+        return False
+    _ensure_local_bin_on_path(show_hint=True)
+    return shutil.which("uv") is not None
+
+
+def _install_ruff() -> bool:
+    command = ["sh", "-c", "curl -LsSf https://astral.sh/ruff/install.sh | sh"]
+    if not _run_install_command(command, "Installing ruff via official installer"):
+        return False
+    _ensure_local_bin_on_path(show_hint=True)
+    return shutil.which("ruff") is not None
+
+
+def _install_jaq() -> bool:  # noqa: PLR0911
+    os_name = system().lower()
+    if os_name == "darwin":
+        if not shutil.which("brew"):
+            console.print("  [red]✗[/red] Homebrew not found; cannot auto-install jaq on macOS.")
+            return False
+        if not _run_install_command(["brew", "install", "jaq"], "Installing jaq with Homebrew"):
+            return False
+        return shutil.which("jaq") is not None
+
+    if os_name != "linux":
+        console.print(f"  [red]✗[/red] Unsupported OS for automatic jaq install: {os_name}")
+        return False
+
+    manager_to_command = {
+        "apt-get": ["apt-get", "install", "-y", "jaq"],
+        "dnf": ["dnf", "install", "-y", "jaq"],
+        "yum": ["yum", "install", "-y", "jaq"],
+        "pacman": ["pacman", "-Sy", "--noconfirm", "jaq"],
+        "apk": ["apk", "add", "jaq"],
+        "zypper": ["zypper", "install", "-y", "jaq"],
+    }
+    manager = _detect_linux_package_manager()
+    base_command = manager_to_command.get(manager)
+    if base_command is None:
+        console.print("  [red]✗[/red] Could not detect a supported Linux package manager for jaq.")
+        return False
+
+    command = _with_sudo_if_needed(base_command)
+    if not _run_install_command(command, f"Installing jaq via {manager}"):
+        return False
+    return shutil.which("jaq") is not None
+
+
+def _guided_install_missing_tools(missing_required: list[str]) -> list[str]:
+    if not missing_required:
+        return []
+
+    installers = {
+        "jaq": _install_jaq,
+        "ruff": _install_ruff,
+        "uv": _install_uv,
+    }
+
+    console.print("\n[bold yellow]Missing required tools detected.[/bold yellow]")
+    if not Confirm.ask("Run guided installer for missing tools now?", default=True):
+        return missing_required
+
+    _ensure_local_bin_on_path()
+    for tool in list(missing_required):
+        if shutil.which(tool):
+            continue
+
+        if not Confirm.ask(f"Install '{tool}' now?", default=True):
+            continue
+
+        installer = installers.get(tool)
+        if installer is None:
+            continue
+
+        if installer():
+            console.print(f"    [green]✓[/green] {tool} installed successfully.")
+            continue
+
+        manual_hint = _manual_install_hint(tool)
+        console.print(f"    [yellow]![/yellow] Could not install {tool} automatically.")
+        console.print(f"    [yellow]Manual:[/yellow] {manual_hint}")
+
+    _ensure_local_bin_on_path()
+    return [tool for tool in REQUIRED_TOOLS if not shutil.which(tool)]
+
+
 def check_tools():
     """Verify that required system tools are installed."""
     console.print("[bold blue]Checking System Dependencies...[/bold blue]")
+    _ensure_local_bin_on_path()
     missing_required = []
 
     for tool, desc in REQUIRED_TOOLS.items():
@@ -187,16 +406,17 @@ def check_tools():
             missing_required.append(tool)
 
     if missing_required:
-        console.print("\n[bold red]Missing required tools. Please install them and run this script again.[/bold red]")
-        if "jaq" in missing_required:
-            console.print(
-                "  [yellow]Note: 'jaq' is a faster alternative to 'jq'. "
-                "On macOS: 'brew install jaq'. "
-                "On Linux: 'apt/pacman install jaq' or download from GitHub.[/yellow]"
-            )
-        # We don't exit here, we let the user proceed to config generation if they want
-        if not Confirm.ask("Continue anyway?"):
+        missing_required = _guided_install_missing_tools(missing_required)
+
+    if missing_required:
+        console.print("\n[bold red]Still missing required tools:[/bold red]")
+        for tool in missing_required:
+            console.print(f"  [red]- {tool}[/red] -> [yellow]{_manual_install_hint(tool)}[/yellow]")
+        console.print("Install them now for full functionality, or continue with limited checks.")
+        if not Confirm.ask("Continue anyway?", default=False):
             raise typer.Exit(code=1)
+    else:
+        console.print("  [green]✓[/green] All required tools are installed.")
 
     console.print("\n[bold blue]Checking Optional Linters...[/bold blue]")
     for tool, desc in OPTIONAL_TOOLS.items():

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -13,6 +13,7 @@ the `.claude/hooks/config.json` configuration file.
 
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess  # noqa: S404  # nosec B404
@@ -22,67 +23,117 @@ from platform import system
 from types import SimpleNamespace
 from typing import Any, cast
 
+
+class _FallbackExit(SystemExit):
+    def __init__(self, code: int = 0) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+class _FallbackTyperError(RuntimeError):
+    def __init__(self) -> None:
+        super().__init__("No command registered on fallback Typer app.")
+
+
+class _FallbackTyper:
+    def __init__(self) -> None:
+        self._main: Any = None
+
+    def command(self):
+        def decorator(func):
+            self._main = func
+            return func
+
+        return decorator
+
+    def __call__(self) -> None:
+        if self._main is None:
+            raise _FallbackTyperError()
+        self._main()
+
+
 typer: Any
 try:
     import typer as _typer
 except ModuleNotFoundError:
-
-    class _FallbackExit(SystemExit):
-        def __init__(self, code: int = 0) -> None:
-            super().__init__(code)
-            self.code = code
-
-    class _FallbackTyper:
-        @staticmethod
-        def command():
-            def decorator(func):
-                return func
-
-            return decorator
-
     typer = SimpleNamespace(Exit=_FallbackExit, Typer=_FallbackTyper)
 else:
     typer = _typer
 
+_RICH_STYLE_TOKENS = {
+    "bold",
+    "dim",
+    "italic",
+    "underline",
+    "blink",
+    "reverse",
+    "strike",
+    "red",
+    "green",
+    "yellow",
+    "blue",
+    "magenta",
+    "cyan",
+    "white",
+    "black",
+}
+_RICH_TAG_PATTERN = re.compile(r"\[([^\]]+)\]")
+
 
 def _strip_rich_markup(value: str) -> str:
-    """Best-effort stripping of rich markup for plain terminal fallback."""
-    cleaned = value
-    while "[" in cleaned and "]" in cleaned:
-        start = cleaned.find("[")
-        end = cleaned.find("]", start)
-        if end == -1:
-            break
-        cleaned = cleaned[:start] + cleaned[end + 1 :]
-    return cleaned
+    """Strip rich-style tags while preserving literal bracket content."""
+
+    def _replace_tag(match: re.Match[str]) -> str:
+        inner = match.group(1).strip()
+        if inner.startswith("/"):
+            inner = inner[1:].strip()
+        tokens = inner.split()
+        if tokens and all(token in _RICH_STYLE_TOKENS for token in tokens):
+            return ""
+        return match.group(0)
+
+    return _RICH_TAG_PATTERN.sub(_replace_tag, value)
 
 
+class _FallbackConsole:
+    @staticmethod
+    def print(*args, **_kwargs) -> None:  # noqa: D102
+        text = " ".join(str(arg) for arg in args)
+        print(_strip_rich_markup(text))
+
+
+class _FallbackPanel:
+    @staticmethod
+    def fit(text: str, style: str = "") -> str:  # noqa: D102
+        del style
+        return text
+
+
+class _FallbackConfirm:
+    @staticmethod
+    def ask(prompt: str, default: bool = True) -> bool:  # noqa: D102
+        suffix = " [Y/n]: " if default else " [y/N]: "
+        answer = input(f"{_strip_rich_markup(prompt)}{suffix}").strip().lower()
+        if not answer:
+            return default
+        return answer in {"y", "yes"}
+
+
+Console: Any
+Panel: Any
+Confirm: Any
 try:
-    from rich.console import Console
-    from rich.panel import Panel
-    from rich.prompt import Confirm
+    from rich.console import Console as _Console
+    from rich.panel import Panel as _Panel
+    from rich.prompt import Confirm as _Confirm
 except ModuleNotFoundError:
-
-    class Console:  # noqa: D101
-        @staticmethod
-        def print(*args, **_kwargs) -> None:  # noqa: D102
-            text = " ".join(str(arg) for arg in args)
-            print(_strip_rich_markup(text))
-
-    class Panel:  # noqa: D101
-        @staticmethod
-        def fit(text: str, style: str = "") -> str:  # noqa: D102
-            del style
-            return text
-
-    class Confirm:  # noqa: D101
-        @staticmethod
-        def ask(prompt: str, default: bool = True) -> bool:  # noqa: D102
-            suffix = " [Y/n]: " if default else " [y/N]: "
-            answer = input(f"{_strip_rich_markup(prompt)}{suffix}").strip().lower()
-            if not answer:
-                return default
-            return answer in {"y", "yes"}
+    Console = _FallbackConsole
+    Panel = _FallbackPanel
+    Confirm = _FallbackConfirm
+else:
+    Console = _Console
+    Panel = _Panel
+    Confirm = _Confirm
 
 
 console = Console()
@@ -165,6 +216,14 @@ DEFAULT_CONFIG = {
 
 SCAN_EXCLUDE_DIRS = {".git", ".venv", "node_modules", ".claude", "__pycache__"}
 LOCAL_BIN_DIR = Path.home() / ".local" / "bin"
+JAQ_LINUX_COMMANDS = {
+    "apt-get": ["apt-get", "install", "-y", "jaq"],
+    "dnf": ["dnf", "install", "-y", "jaq"],
+    "yum": ["yum", "install", "-y", "jaq"],
+    "pacman": ["pacman", "-Sy", "--noconfirm", "jaq"],
+    "apk": ["apk", "add", "jaq"],
+    "zypper": ["zypper", "install", "-y", "jaq"],
+}
 
 
 def _is_excluded_path(path: Path) -> bool:
@@ -235,14 +294,31 @@ def merge_config(existing_config: dict[str, Any], generated_config: dict[str, An
     return merged
 
 
-def _ensure_local_bin_on_path(show_hint: bool = False) -> None:
+def _path_persist_hint() -> str:
+    shell_name = Path(os.environ.get("SHELL", "")).name
+    if shell_name == "bash":
+        return "echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc"
+    if shell_name == "zsh":
+        return "echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.zshrc"
+    if shell_name == "fish":
+        return "fish_add_path ~/.local/bin"
+    return "Add ~/.local/bin to PATH in your shell profile."
+
+
+def _ensure_local_bin_on_path(show_hint: bool = False) -> bool:
     """Ensure ~/.local/bin is available in this process PATH."""
     local_bin = str(LOCAL_BIN_DIR)
-    if LOCAL_BIN_DIR.exists() and local_bin not in os.environ.get("PATH", ""):
-        os.environ["PATH"] = f"{local_bin}:{os.environ.get('PATH', '')}"
-        if show_hint:
-            console.print("  [yellow]![/yellow] Added ~/.local/bin to PATH for this setup run.")
-            console.print("  [yellow]Persist:[/yellow] echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.zshrc")
+    path_entries = os.environ.get("PATH", "").split(os.pathsep)
+    if not LOCAL_BIN_DIR.exists():
+        return False
+    if local_bin in path_entries:
+        return False
+
+    os.environ["PATH"] = f"{local_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+    if show_hint:
+        console.print("  [yellow]![/yellow] Added ~/.local/bin to PATH for this setup run.")
+        console.print(f"  [yellow]Persist:[/yellow] {_path_persist_hint()}")
+    return True
 
 
 def _detect_linux_package_manager() -> str | None:
@@ -266,8 +342,7 @@ def _run_install_command(command: list[str], description: str) -> bool:
     console.print(f"  [cyan]→[/cyan] {description}")
     console.print(f"    [dim]$ {_render_command(command)}[/dim]")
     try:
-        # nosec B603 B607
-        result = subprocess.run(command, check=False)  # noqa: S603,S607
+        result = subprocess.run(command, check=False)  # noqa: S603,S607  # nosec B603 B607
     except FileNotFoundError:
         console.print("    [red]✗[/red] Installer command not found in PATH.")
         return False
@@ -291,16 +366,11 @@ def _manual_install_hint(tool: str) -> str:
     if os_name != "linux":
         return "bash scripts/setup.sh"
 
-    manager_to_command = {
-        "apt-get": "sudo apt-get install -y jaq",
-        "dnf": "sudo dnf install -y jaq",
-        "yum": "sudo yum install -y jaq",
-        "pacman": "sudo pacman -Sy --noconfirm jaq",
-        "apk": "sudo apk add jaq",
-        "zypper": "sudo zypper install -y jaq",
-    }
     manager = _detect_linux_package_manager()
-    return manager_to_command.get(manager, "bash scripts/setup.sh")
+    command = JAQ_LINUX_COMMANDS.get(manager)
+    if command is None:
+        return "bash scripts/setup.sh"
+    return f"sudo {_render_command(command)}"
 
 
 def _install_uv() -> bool:
@@ -333,16 +403,8 @@ def _install_jaq() -> bool:  # noqa: PLR0911
         console.print(f"  [red]✗[/red] Unsupported OS for automatic jaq install: {os_name}")
         return False
 
-    manager_to_command = {
-        "apt-get": ["apt-get", "install", "-y", "jaq"],
-        "dnf": ["dnf", "install", "-y", "jaq"],
-        "yum": ["yum", "install", "-y", "jaq"],
-        "pacman": ["pacman", "-Sy", "--noconfirm", "jaq"],
-        "apk": ["apk", "add", "jaq"],
-        "zypper": ["zypper", "install", "-y", "jaq"],
-    }
     manager = _detect_linux_package_manager()
-    base_command = manager_to_command.get(manager)
+    base_command = JAQ_LINUX_COMMANDS.get(manager)
     if base_command is None:
         console.print("  [red]✗[/red] Could not detect a supported Linux package manager for jaq.")
         return False

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -2,10 +2,13 @@
 
 import importlib.util
 import json
+import os
 import sys
 import types
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 
 def _install_dependency_stubs() -> None:
@@ -79,7 +82,7 @@ def test_has_any_ignores_excluded_directories(tmp_path: Path, monkeypatch) -> No
 
     monkeypatch.chdir(tmp_path)
 
-    assert setup_module._has_any("*.py") is False
+    assert setup_module._has_any("*.py") is False  # nosec B101
 
 
 def test_has_any_finds_recursive_non_excluded_file(tmp_path: Path, monkeypatch) -> None:
@@ -90,7 +93,7 @@ def test_has_any_finds_recursive_non_excluded_file(tmp_path: Path, monkeypatch) 
 
     monkeypatch.chdir(tmp_path)
 
-    assert setup_module._has_any("*.py") is True
+    assert setup_module._has_any("*.py") is True  # nosec B101
 
 
 def test_load_language_defaults_prefers_existing_config(tmp_path: Path, monkeypatch) -> None:
@@ -132,14 +135,14 @@ def test_load_language_defaults_prefers_existing_config(tmp_path: Path, monkeypa
 
     merged = setup_module.load_language_defaults(detected)
 
-    assert merged["python"] is False
-    assert merged["typescript"] is False
-    assert merged["shell"] is True
-    assert merged["dockerfile"] is False
-    assert merged["yaml"] is True
-    assert merged["json"] is False
-    assert merged["toml"] is True
-    assert merged["markdown"] is False
+    assert merged["python"] is False  # nosec B101
+    assert merged["typescript"] is False  # nosec B101
+    assert merged["shell"] is True  # nosec B101
+    assert merged["dockerfile"] is False  # nosec B101
+    assert merged["yaml"] is True  # nosec B101
+    assert merged["json"] is False  # nosec B101
+    assert merged["toml"] is True  # nosec B101
+    assert merged["markdown"] is False  # nosec B101
 
 
 def test_merge_config_preserves_metadata_keys() -> None:
@@ -158,11 +161,11 @@ def test_merge_config_preserves_metadata_keys() -> None:
 
     merged = setup_module.merge_config(existing, generated)
 
-    assert merged["$schema"] == existing["$schema"]
-    assert merged["_comment"] == existing["_comment"]
-    assert merged["custom"] == existing["custom"]
-    assert merged["languages"] == generated["languages"]
-    assert merged["phases"] == generated["phases"]
+    assert merged["$schema"] == existing["$schema"]  # nosec B101
+    assert merged["_comment"] == existing["_comment"]  # nosec B101
+    assert merged["custom"] == existing["custom"]  # nosec B101
+    assert merged["languages"] == generated["languages"]  # nosec B101
+    assert merged["phases"] == generated["phases"]  # nosec B101
 
 
 def test_deep_merge_preserves_nested_keys() -> None:
@@ -190,11 +193,11 @@ def test_deep_merge_preserves_nested_keys() -> None:
     merged = setup_module.merge_config(existing, generated)
 
     # Generated key overwrites
-    assert merged["languages"]["typescript"]["enabled"] is False
-    assert merged["languages"]["python"] is True
+    assert merged["languages"]["typescript"]["enabled"] is False  # nosec B101
+    assert merged["languages"]["python"] is True  # nosec B101
     # Existing nested key survives
-    assert merged["languages"]["typescript"]["knip"] is True
-    assert merged["languages"]["typescript"]["biome_nursery"] == "error"
+    assert merged["languages"]["typescript"]["knip"] is True  # nosec B101
+    assert merged["languages"]["typescript"]["biome_nursery"] == "error"  # nosec B101
 
 
 def test_default_config_no_deprecated_subprocess_keys() -> None:
@@ -202,25 +205,25 @@ def test_default_config_no_deprecated_subprocess_keys() -> None:
     setup_module = _load_setup_module()
 
     subprocess_config = setup_module.DEFAULT_CONFIG.get("subprocess", {})
-    assert "timeout" not in subprocess_config, "DEFAULT_CONFIG has deprecated subprocess.timeout"
-    assert "model_selection" not in subprocess_config, "DEFAULT_CONFIG has deprecated subprocess.model_selection"
+    assert "timeout" not in subprocess_config, "DEFAULT_CONFIG has deprecated subprocess.timeout"  # nosec B101
+    assert "model_selection" not in subprocess_config, "DEFAULT_CONFIG has deprecated subprocess.model_selection"  # nosec B101
 
 
 def test_default_config_uses_correct_exclusion_key() -> None:
     """T9: DEFAULT_CONFIG uses security_linter_exclusions, not exclusions."""
     setup_module = _load_setup_module()
 
-    assert "exclusions" not in setup_module.DEFAULT_CONFIG, (
+    assert "exclusions" not in setup_module.DEFAULT_CONFIG, (  # nosec B101
         "DEFAULT_CONFIG uses 'exclusions' instead of 'security_linter_exclusions'"
     )
-    assert "security_linter_exclusions" in setup_module.DEFAULT_CONFIG, (
+    assert "security_linter_exclusions" in setup_module.DEFAULT_CONFIG, (  # nosec B101
         "DEFAULT_CONFIG missing 'security_linter_exclusions' key"
     )
 
 
 def test_manual_install_hint_uv() -> None:
     setup_module = _load_setup_module()
-    assert setup_module._manual_install_hint("uv") == "curl -LsSf https://astral.sh/uv/install.sh | sh"
+    assert setup_module._manual_install_hint("uv") == "curl -LsSf https://astral.sh/uv/install.sh | sh"  # nosec B101
 
 
 def test_manual_install_hint_linux_jaq_apt(monkeypatch) -> None:
@@ -229,4 +232,115 @@ def test_manual_install_hint_linux_jaq_apt(monkeypatch) -> None:
     monkeypatch.setattr(setup_module, "system", lambda: "Linux")
     monkeypatch.setattr(setup_module, "_detect_linux_package_manager", lambda: "apt-get")
 
-    assert setup_module._manual_install_hint("jaq") == "sudo apt-get install -y jaq"
+    assert setup_module._manual_install_hint("jaq") == "sudo apt-get install -y jaq"  # nosec B101
+
+
+def test_fallback_typer_calls_registered_command() -> None:
+    setup_module = _load_setup_module()
+    app = setup_module._FallbackTyper()
+    called = {"value": False}
+
+    @app.command()
+    def fake_main() -> None:
+        called["value"] = True
+
+    app()
+    assert called["value"] is True  # nosec B101
+
+
+def test_fallback_typer_call_without_command_raises() -> None:
+    setup_module = _load_setup_module()
+    app = setup_module._FallbackTyper()
+    with pytest.raises(RuntimeError):
+        app()
+
+
+def test_strip_rich_markup_preserves_literal_brackets() -> None:
+    setup_module = _load_setup_module()
+    value = "[bold]Ready[/bold] [Y/n] keep [literal]"
+    assert setup_module._strip_rich_markup(value) == "Ready [Y/n] keep [literal]"  # nosec B101
+
+
+def test_ensure_local_bin_on_path_uses_path_tokens(tmp_path: Path, monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    monkeypatch.setattr(setup_module, "LOCAL_BIN_DIR", local_bin)
+    monkeypatch.setenv("PATH", f"{tmp_path}/.local/binutils{os.pathsep}/usr/bin")
+
+    changed = setup_module._ensure_local_bin_on_path()
+    assert changed is True  # nosec B101
+    assert os.environ["PATH"].split(os.pathsep)[0] == str(local_bin)  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("shell", "expected"),
+    [
+        ("/bin/bash", "~/.bashrc"),
+        ("/bin/zsh", "~/.zshrc"),
+        ("/usr/bin/fish", "fish_add_path"),
+        ("", "shell profile"),
+    ],
+)
+def test_path_persist_hint_by_shell(monkeypatch, shell: str, expected: str) -> None:
+    setup_module = _load_setup_module()
+    monkeypatch.setenv("SHELL", shell)
+    hint = setup_module._path_persist_hint()
+    assert expected in hint  # nosec B101
+
+
+def test_with_sudo_if_needed_adds_sudo(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    monkeypatch.setattr(setup_module.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(
+        setup_module.shutil,
+        "which",
+        lambda tool: "/usr/bin/sudo" if tool == "sudo" else f"/usr/bin/{tool}",
+    )
+    assert setup_module._with_sudo_if_needed(["apt-get", "install", "jaq"])[0] == "sudo"  # nosec B101
+
+
+def test_with_sudo_if_needed_keeps_command_for_root(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    monkeypatch.setattr(setup_module.os, "geteuid", lambda: 0)
+    command = ["apt-get", "install", "jaq"]
+    assert setup_module._with_sudo_if_needed(command) == command  # nosec B101
+
+
+def test_guided_install_returns_remaining_missing(monkeypatch, tmp_path: Path) -> None:
+    setup_module = _load_setup_module()
+
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    monkeypatch.setattr(setup_module, "LOCAL_BIN_DIR", local_bin)
+
+    installed = {"jaq"}
+
+    def fake_which(tool: str) -> str | None:
+        if tool in installed:
+            return f"/usr/bin/{tool}"
+        if tool == "sudo":
+            return "/usr/bin/sudo"
+        return None
+
+    answers = iter([True, True, True])  # run installer, install uv, install ruff
+    monkeypatch.setattr(setup_module.Confirm, "ask", lambda *args, **kwargs: next(answers))
+    monkeypatch.setattr(setup_module.shutil, "which", fake_which)
+    monkeypatch.setattr(setup_module, "_install_uv", lambda: installed.add("uv") or True)
+    monkeypatch.setattr(setup_module, "_install_ruff", lambda: False)
+    monkeypatch.setattr(setup_module, "_manual_install_hint", lambda tool: f"manual:{tool}")
+
+    remaining = setup_module._guided_install_missing_tools(["uv", "ruff"])
+    assert remaining == ["ruff"]  # nosec B101
+
+
+def test_manual_hint_uses_shared_jaq_linux_commands(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    monkeypatch.setattr(setup_module, "system", lambda: "Linux")
+    monkeypatch.setattr(setup_module, "_detect_linux_package_manager", lambda: "apt-get")
+    monkeypatch.setitem(
+        setup_module.JAQ_LINUX_COMMANDS,
+        "apt-get",
+        ["apt-get", "install", "-y", "jaq", "--from-shared-map"],
+    )
+    assert "--from-shared-map" in setup_module._manual_install_hint("jaq")  # nosec B101

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -82,7 +82,7 @@ def test_has_any_ignores_excluded_directories(tmp_path: Path, monkeypatch) -> No
 
     monkeypatch.chdir(tmp_path)
 
-    assert setup_module._has_any("*.py") is False  # nosec B101
+    assert setup_module._has_any("*.py") is False
 
 
 def test_has_any_finds_recursive_non_excluded_file(tmp_path: Path, monkeypatch) -> None:
@@ -93,7 +93,7 @@ def test_has_any_finds_recursive_non_excluded_file(tmp_path: Path, monkeypatch) 
 
     monkeypatch.chdir(tmp_path)
 
-    assert setup_module._has_any("*.py") is True  # nosec B101
+    assert setup_module._has_any("*.py") is True
 
 
 def test_load_language_defaults_prefers_existing_config(tmp_path: Path, monkeypatch) -> None:
@@ -135,14 +135,14 @@ def test_load_language_defaults_prefers_existing_config(tmp_path: Path, monkeypa
 
     merged = setup_module.load_language_defaults(detected)
 
-    assert merged["python"] is False  # nosec B101
-    assert merged["typescript"] is False  # nosec B101
-    assert merged["shell"] is True  # nosec B101
-    assert merged["dockerfile"] is False  # nosec B101
-    assert merged["yaml"] is True  # nosec B101
-    assert merged["json"] is False  # nosec B101
-    assert merged["toml"] is True  # nosec B101
-    assert merged["markdown"] is False  # nosec B101
+    assert merged["python"] is False
+    assert merged["typescript"] is False
+    assert merged["shell"] is True
+    assert merged["dockerfile"] is False
+    assert merged["yaml"] is True
+    assert merged["json"] is False
+    assert merged["toml"] is True
+    assert merged["markdown"] is False
 
 
 def test_merge_config_preserves_metadata_keys() -> None:
@@ -161,11 +161,11 @@ def test_merge_config_preserves_metadata_keys() -> None:
 
     merged = setup_module.merge_config(existing, generated)
 
-    assert merged["$schema"] == existing["$schema"]  # nosec B101
-    assert merged["_comment"] == existing["_comment"]  # nosec B101
-    assert merged["custom"] == existing["custom"]  # nosec B101
-    assert merged["languages"] == generated["languages"]  # nosec B101
-    assert merged["phases"] == generated["phases"]  # nosec B101
+    assert merged["$schema"] == existing["$schema"]
+    assert merged["_comment"] == existing["_comment"]
+    assert merged["custom"] == existing["custom"]
+    assert merged["languages"] == generated["languages"]
+    assert merged["phases"] == generated["phases"]
 
 
 def test_deep_merge_preserves_nested_keys() -> None:
@@ -193,11 +193,11 @@ def test_deep_merge_preserves_nested_keys() -> None:
     merged = setup_module.merge_config(existing, generated)
 
     # Generated key overwrites
-    assert merged["languages"]["typescript"]["enabled"] is False  # nosec B101
-    assert merged["languages"]["python"] is True  # nosec B101
+    assert merged["languages"]["typescript"]["enabled"] is False
+    assert merged["languages"]["python"] is True
     # Existing nested key survives
-    assert merged["languages"]["typescript"]["knip"] is True  # nosec B101
-    assert merged["languages"]["typescript"]["biome_nursery"] == "error"  # nosec B101
+    assert merged["languages"]["typescript"]["knip"] is True
+    assert merged["languages"]["typescript"]["biome_nursery"] == "error"
 
 
 def test_default_config_no_deprecated_subprocess_keys() -> None:
@@ -205,25 +205,25 @@ def test_default_config_no_deprecated_subprocess_keys() -> None:
     setup_module = _load_setup_module()
 
     subprocess_config = setup_module.DEFAULT_CONFIG.get("subprocess", {})
-    assert "timeout" not in subprocess_config, "DEFAULT_CONFIG has deprecated subprocess.timeout"  # nosec B101
-    assert "model_selection" not in subprocess_config, "DEFAULT_CONFIG has deprecated subprocess.model_selection"  # nosec B101
+    assert "timeout" not in subprocess_config, "DEFAULT_CONFIG has deprecated subprocess.timeout"
+    assert "model_selection" not in subprocess_config, "DEFAULT_CONFIG has deprecated subprocess.model_selection"
 
 
 def test_default_config_uses_correct_exclusion_key() -> None:
     """T9: DEFAULT_CONFIG uses security_linter_exclusions, not exclusions."""
     setup_module = _load_setup_module()
 
-    assert "exclusions" not in setup_module.DEFAULT_CONFIG, (  # nosec B101
+    assert "exclusions" not in setup_module.DEFAULT_CONFIG, (
         "DEFAULT_CONFIG uses 'exclusions' instead of 'security_linter_exclusions'"
     )
-    assert "security_linter_exclusions" in setup_module.DEFAULT_CONFIG, (  # nosec B101
+    assert "security_linter_exclusions" in setup_module.DEFAULT_CONFIG, (
         "DEFAULT_CONFIG missing 'security_linter_exclusions' key"
     )
 
 
 def test_manual_install_hint_uv() -> None:
     setup_module = _load_setup_module()
-    assert setup_module._manual_install_hint("uv") == "curl -LsSf https://astral.sh/uv/install.sh | sh"  # nosec B101
+    assert setup_module._manual_install_hint("uv") == "curl -LsSf https://astral.sh/uv/install.sh | sh"
 
 
 def test_manual_install_hint_linux_jaq_apt(monkeypatch) -> None:
@@ -232,7 +232,7 @@ def test_manual_install_hint_linux_jaq_apt(monkeypatch) -> None:
     monkeypatch.setattr(setup_module, "system", lambda: "Linux")
     monkeypatch.setattr(setup_module, "_detect_linux_package_manager", lambda: "apt-get")
 
-    assert setup_module._manual_install_hint("jaq") == "sudo apt-get install -y jaq"  # nosec B101
+    assert setup_module._manual_install_hint("jaq") == "sudo apt-get install -y jaq"
 
 
 def test_fallback_typer_calls_registered_command() -> None:
@@ -245,20 +245,20 @@ def test_fallback_typer_calls_registered_command() -> None:
         called["value"] = True
 
     app()
-    assert called["value"] is True  # nosec B101
+    assert called["value"] is True
 
 
 def test_fallback_typer_call_without_command_raises() -> None:
     setup_module = _load_setup_module()
     app = setup_module._FallbackTyper()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(setup_module._FallbackTyperError):
         app()
 
 
 def test_strip_rich_markup_preserves_literal_brackets() -> None:
     setup_module = _load_setup_module()
     value = "[bold]Ready[/bold] [Y/n] keep [literal]"
-    assert setup_module._strip_rich_markup(value) == "Ready [Y/n] keep [literal]"  # nosec B101
+    assert setup_module._strip_rich_markup(value) == "Ready [Y/n] keep [literal]"
 
 
 def test_ensure_local_bin_on_path_uses_path_tokens(tmp_path: Path, monkeypatch) -> None:
@@ -269,8 +269,8 @@ def test_ensure_local_bin_on_path_uses_path_tokens(tmp_path: Path, monkeypatch) 
     monkeypatch.setenv("PATH", f"{tmp_path}/.local/binutils{os.pathsep}/usr/bin")
 
     changed = setup_module._ensure_local_bin_on_path()
-    assert changed is True  # nosec B101
-    assert os.environ["PATH"].split(os.pathsep)[0] == str(local_bin)  # nosec B101
+    assert changed is True
+    assert os.environ["PATH"].split(os.pathsep)[0] == str(local_bin)
 
 
 @pytest.mark.parametrize(
@@ -286,7 +286,7 @@ def test_path_persist_hint_by_shell(monkeypatch, shell: str, expected: str) -> N
     setup_module = _load_setup_module()
     monkeypatch.setenv("SHELL", shell)
     hint = setup_module._path_persist_hint()
-    assert expected in hint  # nosec B101
+    assert expected in hint
 
 
 def test_with_sudo_if_needed_adds_sudo(monkeypatch) -> None:
@@ -297,14 +297,14 @@ def test_with_sudo_if_needed_adds_sudo(monkeypatch) -> None:
         "which",
         lambda tool: "/usr/bin/sudo" if tool == "sudo" else f"/usr/bin/{tool}",
     )
-    assert setup_module._with_sudo_if_needed(["apt-get", "install", "jaq"])[0] == "sudo"  # nosec B101
+    assert setup_module._with_sudo_if_needed(["apt-get", "install", "jaq"])[0] == "sudo"
 
 
 def test_with_sudo_if_needed_keeps_command_for_root(monkeypatch) -> None:
     setup_module = _load_setup_module()
     monkeypatch.setattr(setup_module.os, "geteuid", lambda: 0)
     command = ["apt-get", "install", "jaq"]
-    assert setup_module._with_sudo_if_needed(command) == command  # nosec B101
+    assert setup_module._with_sudo_if_needed(command) == command
 
 
 def test_guided_install_returns_remaining_missing(monkeypatch, tmp_path: Path) -> None:
@@ -331,7 +331,7 @@ def test_guided_install_returns_remaining_missing(monkeypatch, tmp_path: Path) -
     monkeypatch.setattr(setup_module, "_manual_install_hint", lambda tool: f"manual:{tool}")
 
     remaining = setup_module._guided_install_missing_tools(["uv", "ruff"])
-    assert remaining == ["ruff"]  # nosec B101
+    assert remaining == ["ruff"]
 
 
 def test_manual_hint_uses_shared_jaq_linux_commands(monkeypatch) -> None:
@@ -343,4 +343,4 @@ def test_manual_hint_uses_shared_jaq_linux_commands(monkeypatch) -> None:
         "apt-get",
         ["apt-get", "install", "-y", "jaq", "--from-shared-map"],
     )
-    assert "--from-shared-map" in setup_module._manual_install_hint("jaq")  # nosec B101
+    assert "--from-shared-map" in setup_module._manual_install_hint("jaq")

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -216,3 +216,17 @@ def test_default_config_uses_correct_exclusion_key() -> None:
     assert "security_linter_exclusions" in setup_module.DEFAULT_CONFIG, (
         "DEFAULT_CONFIG missing 'security_linter_exclusions' key"
     )
+
+
+def test_manual_install_hint_uv() -> None:
+    setup_module = _load_setup_module()
+    assert setup_module._manual_install_hint("uv") == "curl -LsSf https://astral.sh/uv/install.sh | sh"
+
+
+def test_manual_install_hint_linux_jaq_apt(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+
+    monkeypatch.setattr(setup_module, "system", lambda: "Linux")
+    monkeypatch.setattr(setup_module, "_detect_linux_package_manager", lambda: "apt-get")
+
+    assert setup_module._manual_install_hint("jaq") == "sudo apt-get install -y jaq"


### PR DESCRIPTION
## Summary
- Make `scripts/setup.py` robust on fresh machines (works even before `uv`, `typer`, or `rich` are installed).
- Add interactive guided installation for missing required tools (`uv`, `ruff`, `jaq`) with per-tool confirmation.
- Detect OS/package manager and run appropriate install commands step-by-step.
- Keep `scripts/setup.sh` documented as the non-interactive setup option.
- Update docs to present Python wizard as interactive/default setup path.

## UX Changes
- If required tools are missing, wizard now offers to install each one immediately.
- Shows exact command before execution and manual fallback command if auto-install fails.
- Adds `~/.local/bin` to PATH for current wizard run and prints persistence hint for shell profile.

## Docs
- `README.md`: interactive wizard first, shell script retained as non-interactive alternative.
- `docs/SETUP.md`: same setup split and updated command examples.

## Validation
- `PLANKTON_STRICT_ALLOW_PROTECTED=1 ./scripts/pre_commit_plankton_strict.sh scripts/setup.py tests/unit/test_setup_wizard.py README.md docs/SETUP.md`
- `uv run pytest tests/unit/test_setup_wizard.py -q` (9 passed)
- `uv run ty check scripts/setup.py tests/unit/test_setup_wizard.py`
- `markdownlint-cli2 --no-globs README.md docs/SETUP.md`

## Notes
- `scripts/setup.sh` behavior remains unchanged; it is still the non-interactive installer.