### PR TITLE
Add rerun wizard config editor and guided pre-commit setup

### DIFF
--- a/docs/psf/00-plankton-architecture-overview.md
+++ b/docs/psf/00-plankton-architecture-overview.md
@@ -165,7 +165,7 @@ graph TB
 
 ### multi_linter.sh (PostToolUse Hook)
 
-- **Location**: `.claude/hooks/multi_linter.sh` (~1,606 lines)
+- **Location**: `.claude/hooks/multi_linter.sh` (~1,677 lines)
 - **Responsibilities**:
   - Dispatches files to language-specific handlers based on extension
   - Runs three-phase lint: format, collect
@@ -188,7 +188,7 @@ graph TB
 
 ### protect_linter_configs.sh (PreToolUse Hook)
 
-- **Location**: `.claude/hooks/protect_linter_configs.sh` (~87 lines)
+- **Location**: `.claude/hooks/protect_linter_configs.sh` (~164 lines)
 - **Responsibilities**: Blocks Edit/Write on protected config files and hook scripts
 - **Implementation**: Extracts file path from stdin
   JSON, matches against `config.json` protected list
@@ -198,7 +198,7 @@ graph TB
 
 ### stop_config_guardian.sh (Stop Hook)
 
-- **Location**: `.claude/hooks/stop_config_guardian.sh` (~158 lines)
+- **Location**: `.claude/hooks/stop_config_guardian.sh` (~162 lines)
 - **Responsibilities**: Detects modified config files
   at session end; prompts user to keep or restore
 - **Implementation**: `git diff --name-only` (no LLM).
@@ -230,7 +230,7 @@ graph TB
 
 ### enforce_package_managers.sh (PreToolUse Hook)
 
-- **Location**: `.claude/hooks/enforce_package_managers.sh` (~512 lines)
+- **Location**: `.claude/hooks/enforce_package_managers.sh` (~705 lines)
 - **Responsibilities**: Intercepts legacy package manager
   commands in Bash tool and blocks or warns, suggesting
   project-preferred alternatives (uv for Python, bun for JS)
@@ -245,7 +245,7 @@ graph TB
 
 ### test_hook.sh (Debug/Test Utility)
 
-- **Location**: `.claude/hooks/test_hook.sh` (~2,012 lines)
+- **Location**: `.claude/hooks/test_hook.sh` (~2,089 lines)
 - **Responsibilities**: Self-test suite covering all
   file types, model selection, TS handling, config
   protection, and edge cases
@@ -334,7 +334,7 @@ CI pipeline, and 303+ automated checks.
 - **Quick reference**: `bash .claude/hooks/test_hook.sh --self-test`
   (113 cases), `bash .claude/tests/hooks/verify_feedback_loop.sh`
   (28 checks), `bash tests/stress/run_stress_tests.sh` (133 tests),
-  `.venv/bin/pytest tests/` (297 tests: 267 unit + 30 integration);
+  `.venv/bin/pytest tests/` (334 tests: 304 unit + 30 integration);
   hook investigation tests: `test_nursery_config.sh` (3 tests),
   `test_env_propagation.sh` (3 tests), `test_subprocess_permissions.sh` (5 tests)
 - **Type safety**: Python 3.11+; ty in Phase 2b;
@@ -372,7 +372,7 @@ CI pipeline, and 303+ automated checks.
 
 ## Risks, Tech Debt, Open Questions
 
-- **Shell script size**: `multi_linter.sh` ~1,486
+- **Shell script size**: `multi_linter.sh` ~1,677
   lines; per-language modules would help
 - **Fragile parsing**: yamllint/flake8/markdownlint
   output parsed via `sed`; format changes break it
@@ -397,10 +397,21 @@ for the full benchmark PSF covering all 8 modules, the CLI,
 - **`docs/REFERENCE.md`**: Detailed hook system documentation
   with architecture diagrams, message flow, configuration
   reference, and testing guides
-- **`scripts/setup.py`**: Interactive setup wizard that auto-detects
-  project stack and generates `config.json`
-- **`scripts/init-typescript.sh`**: Initializes
+- **`scripts/setup.py`** (1,086 lines): Interactive setup wizard that
+  auto-detects project stack, generates `config.json`, and supports
+  rerunnable config editing with guided pre-commit setup. Validates
+  dependencies, offers dependency installation via Homebrew/package
+  managers, and configures TypeScript/Python/Shell linting options
+- **`scripts/setup.sh`** (325 lines): Non-interactive installer for
+  CI and scripted environments; mirrors setup.py functionality
+- **`scripts/init-typescript.sh`** (264 lines): Initializes
   TypeScript support (installs Biome, creates configs)
+- **`scripts/pre_commit_plankton_strict.sh`** (160 lines): Strict
+  pre-commit checks for CI enforcement
+- **`scripts/pre_push_plankton_hooks.sh`** (22 lines): Pre-push hook
+  runner for git integration
+- **`scripts/check_commit_message_no_ai_attribution.sh`**: Commit
+  message policy hook enforcing AI attribution rules
 - **`tests/stress/run_stress_tests.sh`**: Stress test
   suite for hook performance under load
 - **`.claude/tests/hooks/`**: Integration test suite

--- a/docs/psf/00-plankton-architecture-overview.md
+++ b/docs/psf/00-plankton-architecture-overview.md
@@ -334,7 +334,7 @@ CI pipeline, and 303+ automated checks.
 - **Quick reference**: `bash .claude/hooks/test_hook.sh --self-test`
   (113 cases), `bash .claude/tests/hooks/verify_feedback_loop.sh`
   (28 checks), `bash tests/stress/run_stress_tests.sh` (133 tests),
-  `.venv/bin/pytest tests/` (344 tests: 314 unit + 30 integration);
+  `.venv/bin/pytest tests/` (345 tests: 315 unit + 30 integration);
   hook investigation tests: `test_nursery_config.sh` (3 tests),
   `test_env_propagation.sh` (3 tests), `test_subprocess_permissions.sh` (5 tests)
 - **Type safety**: Python 3.11+; ty in Phase 2b;

--- a/docs/psf/00-plankton-architecture-overview.md
+++ b/docs/psf/00-plankton-architecture-overview.md
@@ -334,7 +334,7 @@ CI pipeline, and 303+ automated checks.
 - **Quick reference**: `bash .claude/hooks/test_hook.sh --self-test`
   (113 cases), `bash .claude/tests/hooks/verify_feedback_loop.sh`
   (28 checks), `bash tests/stress/run_stress_tests.sh` (133 tests),
-  `.venv/bin/pytest tests/` (334 tests: 304 unit + 30 integration);
+  `.venv/bin/pytest tests/` (344 tests: 314 unit + 30 integration);
   hook investigation tests: `test_nursery_config.sh` (3 tests),
   `test_env_propagation.sh` (3 tests), `test_subprocess_permissions.sh` (5 tests)
 - **Type safety**: Python 3.11+; ty in Phase 2b;

--- a/docs/psf/01-testing-infrastructure.md
+++ b/docs/psf/01-testing-infrastructure.md
@@ -15,7 +15,7 @@
     markdown report generation
   - CI pipeline: pre-commit (lint) + pytest (test) on push/PR
 - **Test totals**: 113 + 28 + 10 + 20 + 133 + 11 = 315 hook checks
-  (+ 103 agent-based integration tests + 344 pytest tests)
+  (+ 103 agent-based integration tests + 345 pytest tests)
 - **Dependencies**: ShellCheck, ruff, jaq, yamllint, hadolint,
   taplo, markdownlint-cli2; biome optional
 
@@ -72,7 +72,7 @@ graph TB
     end
 
     subgraph "Layer 4: Unit Tests"
-        UT[pytest tests/unit/<br/>11 files, 314 tests, swebench + setup coverage]
+        UT[pytest tests/unit/<br/>11 files, 315 tests, swebench + setup coverage]
     end
 
     subgraph "Layer 5: CI"
@@ -301,11 +301,11 @@ graph TB
 
 ## Risks, Tech Debt, Open Questions
 
-- **Pytest tests**: `tests/unit/` (11 files, 314 tests) +
-  `tests/integration/` (7 files, 30 tests) = 344 total;
+- **Pytest tests**: `tests/unit/` (11 files, 315 tests) +
+  `tests/integration/` (7 files, 30 tests) = 345 total;
   see [02-benchmark-swebench.md](02-benchmark-swebench.md)
   for swebench per-file breakdown; `test_setup_wizard.py`
-  (47 tests) covers the interactive setup wizard;
+  (48 tests) covers the interactive setup wizard;
   hook testing remains shell-based
 - **Stress test size**: `run_stress_tests.sh` at 2,347 lines
   is complex; per-category modules would help

--- a/docs/psf/01-testing-infrastructure.md
+++ b/docs/psf/01-testing-infrastructure.md
@@ -15,7 +15,7 @@
     markdown report generation
   - CI pipeline: pre-commit (lint) + pytest (test) on push/PR
 - **Test totals**: 113 + 28 + 10 + 20 + 133 + 11 = 315 hook checks
-  (+ 103 agent-based integration tests + 297 pytest tests)
+  (+ 103 agent-based integration tests + 334 pytest tests)
 - **Dependencies**: ShellCheck, ruff, jaq, yamllint, hadolint,
   taplo, markdownlint-cli2; biome optional
 
@@ -72,7 +72,7 @@ graph TB
     end
 
     subgraph "Layer 4: Unit Tests"
-        UT[pytest tests/unit/<br/>10 files, 267 tests, swebench coverage]
+        UT[pytest tests/unit/<br/>11 files, 304 tests, swebench + setup coverage]
     end
 
     subgraph "Layer 5: CI"
@@ -99,7 +99,7 @@ graph TB
 
 ### test_hook.sh (Self-Test Suite)
 
-- **Location**: `.claude/hooks/test_hook.sh` (~2,012 lines)
+- **Location**: `.claude/hooks/test_hook.sh` (~2,089 lines)
 - **Invocation**: `bash .claude/hooks/test_hook.sh --self-test`
 - **Test count**: 113 pass / 0 fail
 - **Implementation**: `run_self_test()` orchestrates all tests
@@ -301,10 +301,12 @@ graph TB
 
 ## Risks, Tech Debt, Open Questions
 
-- **Pytest tests**: `tests/unit/` (10 files, 267 tests) +
-  `tests/integration/` (7 files, 30 tests) = 297 total;
+- **Pytest tests**: `tests/unit/` (11 files, 304 tests) +
+  `tests/integration/` (7 files, 30 tests) = 334 total;
   see [02-benchmark-swebench.md](02-benchmark-swebench.md)
-  for per-file breakdown; hook testing remains shell-based
+  for swebench per-file breakdown; `test_setup_wizard.py`
+  (37 tests) covers the interactive setup wizard;
+  hook testing remains shell-based
 - **Stress test size**: `run_stress_tests.sh` at 2,347 lines
   is complex; per-category modules would help
 - **Agent tests require TeamCreate**: 103 integration tests

--- a/docs/psf/01-testing-infrastructure.md
+++ b/docs/psf/01-testing-infrastructure.md
@@ -15,7 +15,7 @@
     markdown report generation
   - CI pipeline: pre-commit (lint) + pytest (test) on push/PR
 - **Test totals**: 113 + 28 + 10 + 20 + 133 + 11 = 315 hook checks
-  (+ 103 agent-based integration tests + 334 pytest tests)
+  (+ 103 agent-based integration tests + 344 pytest tests)
 - **Dependencies**: ShellCheck, ruff, jaq, yamllint, hadolint,
   taplo, markdownlint-cli2; biome optional
 
@@ -72,7 +72,7 @@ graph TB
     end
 
     subgraph "Layer 4: Unit Tests"
-        UT[pytest tests/unit/<br/>11 files, 304 tests, swebench + setup coverage]
+        UT[pytest tests/unit/<br/>11 files, 314 tests, swebench + setup coverage]
     end
 
     subgraph "Layer 5: CI"
@@ -301,11 +301,11 @@ graph TB
 
 ## Risks, Tech Debt, Open Questions
 
-- **Pytest tests**: `tests/unit/` (11 files, 304 tests) +
-  `tests/integration/` (7 files, 30 tests) = 334 total;
+- **Pytest tests**: `tests/unit/` (11 files, 314 tests) +
+  `tests/integration/` (7 files, 30 tests) = 344 total;
   see [02-benchmark-swebench.md](02-benchmark-swebench.md)
   for swebench per-file breakdown; `test_setup_wizard.py`
-  (37 tests) covers the interactive setup wizard;
+  (47 tests) covers the interactive setup wizard;
   hook testing remains shell-based
 - **Stress test size**: `run_stress_tests.sh` at 2,347 lines
   is complex; per-category modules would help

--- a/docs/psf/02-benchmark-swebench.md
+++ b/docs/psf/02-benchmark-swebench.md
@@ -5,7 +5,7 @@
 - **Purpose**: Paired A/B benchmark measuring Plankton hook
   impact on SWE-bench task resolution via Claude Code
 - **Scope**: `benchmark/swebench/` (8 Python modules + CLI),
-  `tests/unit/` (10 files, 267 tests),
+  `tests/unit/` (11 files, 304 tests — 10 swebench + 1 setup wizard),
   `tests/integration/` (7 files, 30 tests)
 - **Key responsibilities**:
   - Drive Claude CLI to solve SWE-bench tasks under two
@@ -280,13 +280,14 @@ graph TD
 
 ## Test Coverage
 
-### Unit Tests (267 tests, 10 files)
+### Unit Tests (304 tests, 11 files)
 
 | File | Tests | Coverage |
 | --- | --- | --- |
 | `test_swebench_prereqs.py` | 53 | 15 checks, run_all, format, version |
 | `test_swebench_runner.py` | 49 | flip, reset, hooks, abort, resume, dry_run |
 | `test_swebench_agent.py` | 47 | cmd, solve, parse, patch, cost, dry_run |
+| `test_setup_wizard.py` | 37 | rerunnable config editor, dependency detection |
 | `test_swebench_gate.py` | 33 | 6 criteria, run_gate, format, dry_run |
 | `test_hal_adapter.py` | 26 | dispatch, hooks, errors, metadata, validation |
 | `test_swebench_tasks.py` | 21 | JSONL/HF loading, select, checkout, prepare |
@@ -320,7 +321,7 @@ graph TD
 - **Gate run**: `python -m benchmark.swebench gate --repos-dir DIR`
 - **Full run**: `python -m benchmark.swebench run --repos-dir DIR`
 - **Resume**: `python -m benchmark.swebench run --repos-dir DIR --resume`
-- **Tests**: `.venv/bin/python -m pytest tests -x -v` (297 tests)
+- **Tests**: `.venv/bin/python -m pytest tests -x -v` (334 tests)
 - **HAL harness**: `hal-eval` with `hal_adapter.run` entry point
 
 ## Archive

--- a/docs/psf/02-benchmark-swebench.md
+++ b/docs/psf/02-benchmark-swebench.md
@@ -5,7 +5,7 @@
 - **Purpose**: Paired A/B benchmark measuring Plankton hook
   impact on SWE-bench task resolution via Claude Code
 - **Scope**: `benchmark/swebench/` (8 Python modules + CLI),
-  `tests/unit/` (11 files, 304 tests — 10 swebench + 1 setup wizard),
+  `tests/unit/` (11 files, 314 tests — 10 swebench + 1 setup wizard),
   `tests/integration/` (7 files, 30 tests)
 - **Key responsibilities**:
   - Drive Claude CLI to solve SWE-bench tasks under two
@@ -280,14 +280,14 @@ graph TD
 
 ## Test Coverage
 
-### Unit Tests (304 tests, 11 files)
+### Unit Tests (314 tests, 11 files)
 
 | File | Tests | Coverage |
 | --- | --- | --- |
 | `test_swebench_prereqs.py` | 53 | 15 checks, run_all, format, version |
 | `test_swebench_runner.py` | 49 | flip, reset, hooks, abort, resume, dry_run |
 | `test_swebench_agent.py` | 47 | cmd, solve, parse, patch, cost, dry_run |
-| `test_setup_wizard.py` | 37 | rerunnable config editor, dependency detection |
+| `test_setup_wizard.py` | 47 | rerunnable config editor, dependency detection |
 | `test_swebench_gate.py` | 33 | 6 criteria, run_gate, format, dry_run |
 | `test_hal_adapter.py` | 26 | dispatch, hooks, errors, metadata, validation |
 | `test_swebench_tasks.py` | 21 | JSONL/HF loading, select, checkout, prepare |
@@ -321,7 +321,7 @@ graph TD
 - **Gate run**: `python -m benchmark.swebench gate --repos-dir DIR`
 - **Full run**: `python -m benchmark.swebench run --repos-dir DIR`
 - **Resume**: `python -m benchmark.swebench run --repos-dir DIR --resume`
-- **Tests**: `.venv/bin/python -m pytest tests -x -v` (334 tests)
+- **Tests**: `.venv/bin/python -m pytest tests -x -v` (344 tests)
 - **HAL harness**: `hal-eval` with `hal_adapter.run` entry point
 
 ## Archive

--- a/docs/psf/02-benchmark-swebench.md
+++ b/docs/psf/02-benchmark-swebench.md
@@ -5,7 +5,7 @@
 - **Purpose**: Paired A/B benchmark measuring Plankton hook
   impact on SWE-bench task resolution via Claude Code
 - **Scope**: `benchmark/swebench/` (8 Python modules + CLI),
-  `tests/unit/` (11 files, 314 tests — 10 swebench + 1 setup wizard),
+  `tests/unit/` (11 files, 315 tests — 10 swebench + 1 setup wizard),
   `tests/integration/` (7 files, 30 tests)
 - **Key responsibilities**:
   - Drive Claude CLI to solve SWE-bench tasks under two
@@ -280,14 +280,14 @@ graph TD
 
 ## Test Coverage
 
-### Unit Tests (314 tests, 11 files)
+### Unit Tests (315 tests, 11 files)
 
 | File | Tests | Coverage |
 | --- | --- | --- |
 | `test_swebench_prereqs.py` | 53 | 15 checks, run_all, format, version |
 | `test_swebench_runner.py` | 49 | flip, reset, hooks, abort, resume, dry_run |
 | `test_swebench_agent.py` | 47 | cmd, solve, parse, patch, cost, dry_run |
-| `test_setup_wizard.py` | 47 | rerunnable config editor, dependency detection |
+| `test_setup_wizard.py` | 48 | rerunnable config editor, dependency detection |
 | `test_swebench_gate.py` | 33 | 6 criteria, run_gate, format, dry_run |
 | `test_hal_adapter.py` | 26 | dispatch, hooks, errors, metadata, validation |
 | `test_swebench_tasks.py` | 21 | JSONL/HF loading, select, checkout, prepare |
@@ -321,7 +321,7 @@ graph TD
 - **Gate run**: `python -m benchmark.swebench gate --repos-dir DIR`
 - **Full run**: `python -m benchmark.swebench run --repos-dir DIR`
 - **Resume**: `python -m benchmark.swebench run --repos-dir DIR --resume`
-- **Tests**: `.venv/bin/python -m pytest tests -x -v` (344 tests)
+- **Tests**: `.venv/bin/python -m pytest tests -x -v` (345 tests)
 - **HAL harness**: `hal-eval` with `hal_adapter.run` entry point
 
 ## Archive

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -19,6 +19,7 @@ import shutil
 import subprocess  # noqa: S404  # nosec B404
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from copy import deepcopy
 from pathlib import Path
@@ -297,37 +298,6 @@ def _has_any(pattern: str) -> bool:
     return any(match.is_file() and not _is_excluded_path(match) for match in Path(".").rglob(pattern))
 
 
-def load_language_defaults(detected: dict[str, bool]) -> dict[str, bool]:
-    """Merge detected language defaults with existing config language choices."""
-    defaults = dict(detected)
-    if not CONFIG_PATH.exists():
-        return defaults
-
-    try:
-        with open(CONFIG_PATH, encoding="utf-8") as file_handle:
-            existing_config = json.load(file_handle)
-    except Exception:
-        return defaults
-
-    languages = existing_config.get("languages")
-    if not isinstance(languages, dict):
-        return defaults
-
-    simple_languages = ["python", "shell", "dockerfile", "yaml", "json", "toml", "markdown"]
-    for language in simple_languages:
-        existing_value = languages.get(language)
-        if isinstance(existing_value, bool):
-            defaults[language] = existing_value
-
-    existing_typescript = languages.get("typescript")
-    if isinstance(existing_typescript, bool):
-        defaults["typescript"] = existing_typescript
-    elif isinstance(existing_typescript, dict):
-        defaults["typescript"] = bool(existing_typescript.get("enabled", True))
-
-    return defaults
-
-
 def load_existing_config() -> dict[str, Any]:
     """Load existing config file if present and valid, else return empty dict."""
     if not CONFIG_PATH.exists():
@@ -369,7 +339,11 @@ def build_effective_config(existing_config: dict[str, Any]) -> dict[str, Any]:
 
 def _ask_text(prompt: str, default: str) -> str:
     suffix = f" [{default}]" if default else ""
-    answer = input(f"{prompt}{suffix}: ").strip()
+    try:
+        answer = input(f"{prompt}{suffix}: ").strip()
+    except EOFError:
+        console.print("  [yellow]![/yellow] Input closed; using default value.")
+        return default
     return answer or default
 
 
@@ -534,7 +508,11 @@ def _fetch_latest_release_asset_url(repo: str, pattern: str) -> str | None:
         if not isinstance(asset, dict):
             continue
         download_url = asset.get("browser_download_url")
-        if isinstance(download_url, str) and pattern in download_url:
+        if not isinstance(download_url, str):
+            continue
+        parsed = urllib.parse.urlparse(download_url)
+        filename = Path(parsed.path).name
+        if filename == pattern:
             return download_url
     return None
 
@@ -1024,10 +1002,10 @@ def main():
         console.print(f"  [yellow]Could not parse existing {CONFIG_PATH}, starting fresh.[/yellow]")
 
     section_selection = select_sections(has_existing_config=bool(existing_config))
+    new_config: dict[str, Any] | None = None
     if not any(section_selection.values()):
         if existing_config:
             console.print("  [yellow]![/yellow] No sections selected; existing configuration will be kept unchanged.")
-            new_config = existing_config
         else:
             console.print("  [red]✗[/red] No sections selected and no existing config found; aborting.")
             raise typer.Exit(code=1)
@@ -1035,14 +1013,15 @@ def main():
         generated_config = configure_selected_sections(effective_config, prompt_defaults, section_selection)
         new_config = merge_config(existing_config, generated_config)
 
-    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-
-    # Write config
-    console.print(f"\n[bold]Writing configuration to {CONFIG_PATH}...[/bold]")
-    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
-        json.dump(new_config, f, indent=2)
-        f.write("\n")
-    console.print("  [green]✓[/green] Configuration saved.")
+    if new_config is not None:
+        CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        console.print(f"\n[bold]Writing configuration to {CONFIG_PATH}...[/bold]")
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+            json.dump(new_config, f, indent=2)
+            f.write("\n")
+        console.print("  [green]✓[/green] Configuration saved.")
+    else:
+        console.print("\n[bold]Configuration unchanged; skipping file write.[/bold]")
 
     setup_hooks()
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -19,7 +19,6 @@ import shutil
 import subprocess  # noqa: S404  # nosec B404
 import sys
 import urllib.error
-import urllib.parse
 import urllib.request
 from copy import deepcopy
 from pathlib import Path
@@ -298,6 +297,37 @@ def _has_any(pattern: str) -> bool:
     return any(match.is_file() and not _is_excluded_path(match) for match in Path(".").rglob(pattern))
 
 
+def load_language_defaults(detected: dict[str, bool]) -> dict[str, bool]:
+    """Merge detected language defaults with existing config language choices."""
+    defaults = dict(detected)
+    if not CONFIG_PATH.exists():
+        return defaults
+
+    try:
+        with open(CONFIG_PATH, encoding="utf-8") as file_handle:
+            existing_config = json.load(file_handle)
+    except Exception:
+        return defaults
+
+    languages = existing_config.get("languages")
+    if not isinstance(languages, dict):
+        return defaults
+
+    simple_languages = ["python", "shell", "dockerfile", "yaml", "json", "toml", "markdown"]
+    for language in simple_languages:
+        existing_value = languages.get(language)
+        if isinstance(existing_value, bool):
+            defaults[language] = existing_value
+
+    existing_typescript = languages.get("typescript")
+    if isinstance(existing_typescript, bool):
+        defaults["typescript"] = existing_typescript
+    elif isinstance(existing_typescript, dict):
+        defaults["typescript"] = bool(existing_typescript.get("enabled", True))
+
+    return defaults
+
+
 def load_existing_config() -> dict[str, Any]:
     """Load existing config file if present and valid, else return empty dict."""
     if not CONFIG_PATH.exists():
@@ -339,11 +369,7 @@ def build_effective_config(existing_config: dict[str, Any]) -> dict[str, Any]:
 
 def _ask_text(prompt: str, default: str) -> str:
     suffix = f" [{default}]" if default else ""
-    try:
-        answer = input(f"{prompt}{suffix}: ").strip()
-    except EOFError:
-        console.print("  [yellow]![/yellow] Input closed; using default value.")
-        return default
+    answer = input(f"{prompt}{suffix}: ").strip()
     return answer or default
 
 
@@ -508,11 +534,7 @@ def _fetch_latest_release_asset_url(repo: str, pattern: str) -> str | None:
         if not isinstance(asset, dict):
             continue
         download_url = asset.get("browser_download_url")
-        if not isinstance(download_url, str):
-            continue
-        parsed = urllib.parse.urlparse(download_url)
-        filename = Path(parsed.path).name
-        if filename == pattern:
+        if isinstance(download_url, str) and pattern in download_url:
             return download_url
     return None
 
@@ -1002,10 +1024,10 @@ def main():
         console.print(f"  [yellow]Could not parse existing {CONFIG_PATH}, starting fresh.[/yellow]")
 
     section_selection = select_sections(has_existing_config=bool(existing_config))
-    new_config: dict[str, Any] | None = None
     if not any(section_selection.values()):
         if existing_config:
             console.print("  [yellow]![/yellow] No sections selected; existing configuration will be kept unchanged.")
+            new_config = existing_config
         else:
             console.print("  [red]✗[/red] No sections selected and no existing config found; aborting.")
             raise typer.Exit(code=1)
@@ -1013,15 +1035,14 @@ def main():
         generated_config = configure_selected_sections(effective_config, prompt_defaults, section_selection)
         new_config = merge_config(existing_config, generated_config)
 
-    if new_config is not None:
-        CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        console.print(f"\n[bold]Writing configuration to {CONFIG_PATH}...[/bold]")
-        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
-            json.dump(new_config, f, indent=2)
-            f.write("\n")
-        console.print("  [green]✓[/green] Configuration saved.")
-    else:
-        console.print("\n[bold]Configuration unchanged; skipping file write.[/bold]")
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write config
+    console.print(f"\n[bold]Writing configuration to {CONFIG_PATH}...[/bold]")
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(new_config, f, indent=2)
+        f.write("\n")
+    console.print("  [green]✓[/green] Configuration saved.")
 
     setup_hooks()
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -414,6 +414,9 @@ def select_sections(has_existing_config: bool) -> dict[str, bool]:
         "subprocess": not has_existing_config,
     }
 
+    if has_existing_config and not Confirm.ask("Make targeted edits to specific sections?", default=False):
+        return {key: False for key in defaults}
+
     prompts = [
         ("languages", "Edit language enforcement settings?"),
         ("phases", "Edit phases (auto_format, subprocess_delegation)?"),
@@ -619,6 +622,29 @@ def _install_jaq() -> bool:  # noqa: PLR0911
     return False
 
 
+def _install_pre_commit() -> bool:
+    """Attempt to install pre-commit using available package tooling."""
+    install_commands: list[tuple[list[str], str]] = []
+    if shutil.which("uv"):
+        install_commands.append((["uv", "tool", "install", "pre-commit"], "Installing pre-commit via uv tool"))
+    if shutil.which("pipx"):
+        install_commands.append((["pipx", "install", "pre-commit"], "Installing pre-commit via pipx"))
+
+    python_cmd = shutil.which("python3") or shutil.which("python")
+    if python_cmd:
+        install_commands.append(
+            ([python_cmd, "-m", "pip", "install", "--user", "pre-commit"], "Installing pre-commit via pip --user")
+        )
+
+    for command, description in install_commands:
+        if not _run_install_command(command, description):
+            continue
+        _ensure_local_bin_on_path(show_hint=True)
+        if shutil.which("pre-commit"):
+            return True
+    return False
+
+
 def _guided_install_missing_tools(missing_required: list[str]) -> list[str]:
     if not missing_required:
         return []
@@ -662,14 +688,19 @@ def check_tools():
     console.print("[bold blue]Checking System Dependencies...[/bold blue]")
     _ensure_local_bin_on_path()
     missing_required = []
+    required_tools = list(REQUIRED_TOOLS.keys())
+    console.print(f"  Required tools: {', '.join(required_tools)}")
+    found_required = 0
 
     for tool, desc in REQUIRED_TOOLS.items():
         path = shutil.which(tool)
         if path:
             console.print(f"  [green]✓[/green] {tool} found at {path}")
+            found_required += 1
         else:
             console.print(f"  [red]✗[/red] {tool} NOT found. {desc}")
             missing_required.append(tool)
+    console.print(f"  Required tool status: {found_required}/{len(required_tools)} present")
 
     if missing_required:
         missing_required = _guided_install_missing_tools(missing_required)
@@ -953,6 +984,37 @@ def configure_selected_sections(
     return generated
 
 
+def _install_pre_commit_hooks() -> None:
+    console.print("  Installing pre-commit hooks...")
+    try:
+        subprocess.run(["pre-commit", "install"], check=True)  # noqa: S607  # nosec B603 B607
+        console.print("    [green]✓[/green] pre-commit hooks installed")
+    except subprocess.CalledProcessError:
+        console.print("    [red]✗[/red] pre-commit install failed")
+
+
+def _ensure_pre_commit_ready() -> None:
+    if not Path(".pre-commit-config.yaml").exists():
+        return
+
+    if shutil.which("pre-commit"):
+        _install_pre_commit_hooks()
+        return
+
+    console.print("  [yellow]![/yellow] .pre-commit-config.yaml found but 'pre-commit' not installed.")
+    if not Confirm.ask("Install pre-commit now?", default=True):
+        console.print("  [yellow]![/yellow] Skipping pre-commit installation.")
+        return
+
+    if not _install_pre_commit():
+        console.print("  [red]✗[/red] Could not install pre-commit automatically.")
+        console.print("  [yellow]Manual:[/yellow] uv tool install pre-commit")
+        return
+
+    console.print("  [green]✓[/green] pre-commit installed")
+    _install_pre_commit_hooks()
+
+
 def setup_hooks():
     """Ensure hooks directory exists and scripts are executable."""
     console.print("\n[bold blue]Setting up Hooks...[/bold blue]")
@@ -971,17 +1033,7 @@ def setup_hooks():
         os.chmod(script, 0o755)  # noqa: S103  # nosec B103
         console.print(f"    [green]✓[/green] chmod +x {script.name}")
 
-    # Check pre-commit
-    if Path(".pre-commit-config.yaml").exists():
-        if shutil.which("pre-commit"):
-            console.print("  Installing pre-commit hooks...")
-            try:
-                subprocess.run(["pre-commit", "install"], check=True)  # noqa: S607  # nosec B603 B607
-                console.print("    [green]✓[/green] pre-commit installed")
-            except subprocess.CalledProcessError:
-                console.print("    [red]✗[/red] pre-commit install failed")
-        else:
-            console.print("  [yellow]![/yellow] .pre-commit-config.yaml found but 'pre-commit' not installed.")
+    _ensure_pre_commit_ready()
 
 
 @app.command()
@@ -1005,7 +1057,7 @@ def main():
     new_config: dict[str, Any] | None = None
     if not any(section_selection.values()):
         if existing_config:
-            console.print("  [yellow]![/yellow] No sections selected; existing configuration will be kept unchanged.")
+            console.print("  Existing configuration will be kept unchanged.")
         else:
             console.print("  [red]✗[/red] No sections selected and no existing config found; aborting.")
             raise typer.Exit(code=1)

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -459,6 +459,31 @@ def _ensure_local_bin_on_path(show_hint: bool = False) -> bool:
     return True
 
 
+def _ensure_pip_user_bin_on_path() -> bool:
+    """Ensure macOS pip --user script dirs are on PATH.
+
+    pip --user installs scripts to ~/Library/Python/<version>/bin on macOS
+    (system Python), unlike ~/.local/bin on Linux. Glob all version dirs.
+    """
+    macos_pip_base = Path.home() / "Library" / "Python"
+    if not macos_pip_base.exists():
+        return False
+    added = False
+    path_entries = os.environ.get("PATH", "").split(os.pathsep)
+
+    def _version_key(p: Path) -> tuple[int, ...]:
+        try:
+            return tuple(int(x) for x in p.parent.name.split("."))
+        except ValueError:
+            return (0,)
+
+    for bin_dir in sorted(macos_pip_base.glob("*/bin"), key=_version_key):
+        if str(bin_dir) not in path_entries:
+            os.environ["PATH"] = f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"
+            added = True
+    return added
+
+
 def _detect_linux_package_manager() -> str | None:
     for manager in ("apt-get", "dnf", "yum", "pacman", "apk", "zypper"):
         if shutil.which(manager):
@@ -630,6 +655,8 @@ def _install_pre_commit() -> bool:
     if shutil.which("pipx"):
         install_commands.append((["pipx", "install", "pre-commit"], "Installing pre-commit via pipx"))
 
+    # pip --user is acceptable here: the setup wizard bootstraps tooling
+    # before hooks are active, so enforce_package_managers won't block it.
     python_cmd = shutil.which("python3") or shutil.which("python")
     if python_cmd:
         install_commands.append(
@@ -640,6 +667,7 @@ def _install_pre_commit() -> bool:
         if not _run_install_command(command, description):
             continue
         _ensure_local_bin_on_path(show_hint=True)
+        _ensure_pip_user_bin_on_path()
         if shutil.which("pre-commit"):
             return True
     return False
@@ -987,10 +1015,13 @@ def configure_selected_sections(
 def _install_pre_commit_hooks() -> None:
     console.print("  Installing pre-commit hooks...")
     try:
-        subprocess.run(["pre-commit", "install"], check=True)  # noqa: S607  # nosec B603 B607
+        subprocess.run(["pre-commit", "install"], check=True, capture_output=True)  # noqa: S607  # nosec B603 B607
         console.print("    [green]✓[/green] pre-commit hooks installed")
-    except subprocess.CalledProcessError:
-        console.print("    [red]✗[/red] pre-commit install failed")
+    except FileNotFoundError:
+        console.print("    [red]✗[/red] pre-commit install failed: binary not found in PATH")
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or b"").decode("utf-8", errors="replace").strip()
+        console.print(f"    [red]✗[/red] pre-commit install failed{': ' + detail if detail else ''}")
 
 
 def _ensure_pre_commit_ready() -> None:

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -468,8 +468,6 @@ def _ensure_pip_user_bin_on_path() -> bool:
     macos_pip_base = Path.home() / "Library" / "Python"
     if not macos_pip_base.exists():
         return False
-    added = False
-    path_entries = os.environ.get("PATH", "").split(os.pathsep)
 
     def _version_key(p: Path) -> tuple[int, ...]:
         try:
@@ -477,11 +475,20 @@ def _ensure_pip_user_bin_on_path() -> bool:
         except ValueError:
             return (0,)
 
-    for bin_dir in sorted(macos_pip_base.glob("*/bin"), key=_version_key):
-        if str(bin_dir) not in path_entries:
-            os.environ["PATH"] = f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"
-            added = True
-    return added
+    # Sort descending so highest version (e.g. 3.13) gets highest PATH priority
+    all_bin_dirs = sorted(macos_pip_base.glob("*/bin"), key=_version_key, reverse=True)
+    if not all_bin_dirs:
+        return False
+
+    bin_dir_strs = {str(d) for d in all_bin_dirs}
+    current_path = os.environ.get("PATH", "")
+    remaining = [e for e in current_path.split(os.pathsep) if e not in bin_dir_strs]
+    new_path = os.pathsep.join([str(d) for d in all_bin_dirs] + remaining)
+
+    if current_path == new_path:
+        return False
+    os.environ["PATH"] = new_path
+    return True
 
 
 def _detect_linux_package_manager() -> str | None:

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -674,7 +674,8 @@ def _install_pre_commit() -> bool:
         if not _run_install_command(command, description):
             continue
         _ensure_local_bin_on_path(show_hint=True)
-        _ensure_pip_user_bin_on_path()
+        if "--user" in command:
+            _ensure_pip_user_bin_on_path()
         if shutil.which("pre-commit"):
             return True
     return False

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -96,31 +96,22 @@ def test_has_any_finds_recursive_non_excluded_file(tmp_path: Path, monkeypatch) 
     assert setup_module._has_any("*.py") is True
 
 
-def test_load_language_defaults_prefers_existing_config(tmp_path: Path, monkeypatch) -> None:
+def test_language_defaults_from_effective_prefers_existing_config() -> None:
     setup_module = _load_setup_module()
-
-    config_dir = tmp_path / ".claude" / "hooks"
-    config_dir.mkdir(parents=True)
-    config_path = config_dir / "config.json"
-    config_path.write_text(
-        json.dumps(
-            {
-                "languages": {
-                    "python": False,
-                    "shell": True,
-                    "dockerfile": False,
-                    "yaml": True,
-                    "json": False,
-                    "toml": True,
-                    "markdown": False,
-                    "typescript": {"enabled": False},
-                }
+    effective = setup_module.build_effective_config(
+        {
+            "languages": {
+                "python": False,
+                "shell": True,
+                "dockerfile": False,
+                "yaml": True,
+                "json": False,
+                "toml": True,
+                "markdown": False,
+                "typescript": {"enabled": False},
             }
-        ),
-        encoding="utf-8",
+        }
     )
-
-    monkeypatch.chdir(tmp_path)
 
     detected = {
         "python": True,
@@ -133,7 +124,7 @@ def test_load_language_defaults_prefers_existing_config(tmp_path: Path, monkeypa
         "markdown": True,
     }
 
-    merged = setup_module.load_language_defaults(detected)
+    merged = setup_module.language_defaults_from_effective(detected, effective)
 
     assert merged["python"] is False
     assert merged["typescript"] is False
@@ -349,6 +340,40 @@ def test_guided_install_returns_remaining_missing(monkeypatch, tmp_path: Path) -
     assert remaining == ["ruff"]
 
 
+def test_fetch_latest_release_asset_url_ignores_checksum_assets(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+
+    class _FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def read(self) -> bytes:
+            payload = {
+                "assets": [
+                    {
+                        "browser_download_url": (
+                            "https://github.com/01mf02/jaq/releases/download/v2.1.1/"
+                            "jaq-x86_64-unknown-linux-musl.sha256"
+                        )
+                    },
+                    {
+                        "browser_download_url": (
+                            "https://github.com/01mf02/jaq/releases/download/v2.1.1/jaq-x86_64-unknown-linux-musl"
+                        )
+                    },
+                ]
+            }
+            return json.dumps(payload).encode("utf-8")
+
+    monkeypatch.setattr(setup_module.urllib.request, "urlopen", lambda *args, **kwargs: _FakeResponse())
+    url = setup_module._fetch_latest_release_asset_url("01mf02/jaq", "jaq-x86_64-unknown-linux-musl")
+    assert url is not None
+    assert url.endswith("jaq-x86_64-unknown-linux-musl")
+
+
 def test_manual_hint_uses_shared_jaq_linux_commands(monkeypatch) -> None:
     setup_module = _load_setup_module()
     monkeypatch.setattr(setup_module, "system", lambda: "Linux")
@@ -435,16 +460,86 @@ def test_select_sections_defaults_on_rerun(monkeypatch) -> None:
     assert selected["subprocess"] is False
 
 
+def test_main_no_sections_selected_does_not_rewrite_existing_config(tmp_path: Path, monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    monkeypatch.chdir(tmp_path)
+
+    config_path = tmp_path / ".claude" / "hooks" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text('{"languages":{"python":false}}\n', encoding="utf-8")
+    original = config_path.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(setup_module, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(setup_module, "check_tools", lambda: None)
+    monkeypatch.setattr(setup_module, "setup_hooks", lambda: None)
+    monkeypatch.setattr(
+        setup_module,
+        "load_existing_config",
+        lambda: {"languages": {"python": False}},
+    )
+    monkeypatch.setattr(
+        setup_module,
+        "detect_languages",
+        lambda: {
+            "python": True,
+            "typescript": False,
+            "shell": False,
+            "dockerfile": False,
+            "yaml": False,
+            "json": False,
+            "toml": False,
+            "markdown": False,
+        },
+    )
+    monkeypatch.setattr(
+        setup_module,
+        "select_sections",
+        lambda has_existing_config: {
+            "languages": False,
+            "phases": False,
+            "security_exclusions": False,
+            "package_managers": False,
+            "jscpd": False,
+            "subprocess": False,
+        },
+    )
+
+    setup_module.main()
+    assert config_path.read_text(encoding="utf-8") == original
+
+
 def test_edit_list_items_add_and_remove(monkeypatch) -> None:
     setup_module = _load_setup_module()
-    answers = iter([True, False, True, False, True, False])
+    answers = {
+        "Add an item?": [True, False],
+        "Remove an item?": [False, True],
+        "Edit this list again?": [True, False],
+    }
     inputs = iter(["c", "2"])
 
-    monkeypatch.setattr(setup_module.Confirm, "ask", lambda *args, **kwargs: next(answers))
+    def fake_confirm(prompt: str, default: bool = False) -> bool:
+        queue = answers.get(prompt)
+        if queue is None or not queue:
+            raise AssertionError(f"Unexpected prompt or too many calls: {prompt!r}")
+        return queue.pop(0)
+
+    monkeypatch.setattr(setup_module.Confirm, "ask", fake_confirm)
     monkeypatch.setattr(setup_module, "_ask_text", lambda *args, **kwargs: next(inputs))
 
     result = setup_module.edit_list_items("Test List", ["a", "b"])
     assert result == ["a", "c"]
+
+
+def test_ask_text_returns_default_on_eof(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    monkeypatch.setattr("builtins.input", lambda _prompt: (_ for _ in ()).throw(EOFError))
+    assert setup_module._ask_text("Prompt", "fallback") == "fallback"
+
+
+def test_ask_int_returns_default_on_eof(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    monkeypatch.setattr("builtins.input", lambda _prompt: (_ for _ in ()).throw(EOFError))
+    assert setup_module._ask_int("Prompt", 7, min_value=0) == 7
 
 
 def test_configure_package_managers_uses_current_values(monkeypatch) -> None:

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -96,22 +96,31 @@ def test_has_any_finds_recursive_non_excluded_file(tmp_path: Path, monkeypatch) 
     assert setup_module._has_any("*.py") is True
 
 
-def test_language_defaults_from_effective_prefers_existing_config() -> None:
+def test_load_language_defaults_prefers_existing_config(tmp_path: Path, monkeypatch) -> None:
     setup_module = _load_setup_module()
-    effective = setup_module.build_effective_config(
-        {
-            "languages": {
-                "python": False,
-                "shell": True,
-                "dockerfile": False,
-                "yaml": True,
-                "json": False,
-                "toml": True,
-                "markdown": False,
-                "typescript": {"enabled": False},
+
+    config_dir = tmp_path / ".claude" / "hooks"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "languages": {
+                    "python": False,
+                    "shell": True,
+                    "dockerfile": False,
+                    "yaml": True,
+                    "json": False,
+                    "toml": True,
+                    "markdown": False,
+                    "typescript": {"enabled": False},
+                }
             }
-        }
+        ),
+        encoding="utf-8",
     )
+
+    monkeypatch.chdir(tmp_path)
 
     detected = {
         "python": True,
@@ -124,7 +133,7 @@ def test_language_defaults_from_effective_prefers_existing_config() -> None:
         "markdown": True,
     }
 
-    merged = setup_module.language_defaults_from_effective(detected, effective)
+    merged = setup_module.load_language_defaults(detected)
 
     assert merged["python"] is False
     assert merged["typescript"] is False
@@ -340,40 +349,6 @@ def test_guided_install_returns_remaining_missing(monkeypatch, tmp_path: Path) -
     assert remaining == ["ruff"]
 
 
-def test_fetch_latest_release_asset_url_ignores_checksum_assets(monkeypatch) -> None:
-    setup_module = _load_setup_module()
-
-    class _FakeResponse:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb) -> bool:
-            return False
-
-        def read(self) -> bytes:
-            payload = {
-                "assets": [
-                    {
-                        "browser_download_url": (
-                            "https://github.com/01mf02/jaq/releases/download/v2.1.1/"
-                            "jaq-x86_64-unknown-linux-musl.sha256"
-                        )
-                    },
-                    {
-                        "browser_download_url": (
-                            "https://github.com/01mf02/jaq/releases/download/v2.1.1/jaq-x86_64-unknown-linux-musl"
-                        )
-                    },
-                ]
-            }
-            return json.dumps(payload).encode("utf-8")
-
-    monkeypatch.setattr(setup_module.urllib.request, "urlopen", lambda *args, **kwargs: _FakeResponse())
-    url = setup_module._fetch_latest_release_asset_url("01mf02/jaq", "jaq-x86_64-unknown-linux-musl")
-    assert url is not None
-    assert url.endswith("jaq-x86_64-unknown-linux-musl")
-
-
 def test_manual_hint_uses_shared_jaq_linux_commands(monkeypatch) -> None:
     setup_module = _load_setup_module()
     monkeypatch.setattr(setup_module, "system", lambda: "Linux")
@@ -460,88 +435,16 @@ def test_select_sections_defaults_on_rerun(monkeypatch) -> None:
     assert selected["subprocess"] is False
 
 
-def test_main_no_sections_selected_does_not_rewrite_existing_config(tmp_path: Path, monkeypatch) -> None:
-    setup_module = _load_setup_module()
-    monkeypatch.chdir(tmp_path)
-
-    config_path = tmp_path / ".claude" / "hooks" / "config.json"
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text('{"languages":{"python":false}}\n', encoding="utf-8")
-    original = config_path.read_text(encoding="utf-8")
-
-    monkeypatch.setattr(setup_module, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(setup_module, "check_tools", lambda: None)
-    monkeypatch.setattr(setup_module, "setup_hooks", lambda: None)
-    monkeypatch.setattr(
-        setup_module,
-        "load_existing_config",
-        lambda: {"languages": {"python": False}},
-    )
-    monkeypatch.setattr(
-        setup_module,
-        "detect_languages",
-        lambda: {
-            "python": True,
-            "typescript": False,
-            "shell": False,
-            "dockerfile": False,
-            "yaml": False,
-            "json": False,
-            "toml": False,
-            "markdown": False,
-        },
-    )
-    monkeypatch.setattr(
-        setup_module,
-        "select_sections",
-        lambda has_existing_config: {
-            "languages": False,
-            "phases": False,
-            "security_exclusions": False,
-            "package_managers": False,
-            "jscpd": False,
-            "subprocess": False,
-        },
-    )
-
-    setup_module.main()
-    assert config_path.read_text(encoding="utf-8") == original
-
-
 def test_edit_list_items_add_and_remove(monkeypatch) -> None:
     setup_module = _load_setup_module()
-    answers = {
-        "Add an item?": [True, False],
-        "Remove an item?": [False, True],
-        "Edit this list again?": [True, False],
-    }
+    answers = iter([True, False, True, False, True, False])
     inputs = iter(["c", "2"])
 
-    def fake_confirm(prompt: str, default: bool = False) -> bool:
-        queue = answers.get(prompt)
-        if queue is None or not queue:
-            raise AssertionError(f"Unexpected prompt or too many calls: {prompt!r}")
-        return queue.pop(0)
-
-    monkeypatch.setattr(setup_module.Confirm, "ask", fake_confirm)
+    monkeypatch.setattr(setup_module.Confirm, "ask", lambda *args, **kwargs: next(answers))
     monkeypatch.setattr(setup_module, "_ask_text", lambda *args, **kwargs: next(inputs))
 
     result = setup_module.edit_list_items("Test List", ["a", "b"])
     assert result == ["a", "c"]
-
-
-def test_ask_text_returns_default_on_eof(monkeypatch) -> None:
-    setup_module = _load_setup_module()
-    monkeypatch.setattr("builtins.input", lambda _prompt: (_ for _ in ()).throw(EOFError))
-    assert setup_module._ask_text("Prompt", "fallback") == "fallback"
-
-
-def test_ask_int_returns_default_on_eof(monkeypatch) -> None:
-    setup_module = _load_setup_module()
-    monkeypatch.setattr("builtins.input", lambda _prompt: (_ for _ in ()).throw(EOFError))
-    # _ask_int delegates to _ask_text(..., str(default)); on EOF that path
-    # returns the default string, which _ask_int converts back to int.
-    assert setup_module._ask_int("Prompt", 7, min_value=0) == 7
 
 
 def test_configure_package_managers_uses_current_values(monkeypatch) -> None:

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -539,6 +539,8 @@ def test_ask_text_returns_default_on_eof(monkeypatch) -> None:
 def test_ask_int_returns_default_on_eof(monkeypatch) -> None:
     setup_module = _load_setup_module()
     monkeypatch.setattr("builtins.input", lambda _prompt: (_ for _ in ()).throw(EOFError))
+    # _ask_int delegates to _ask_text(..., str(default)); on EOF that path
+    # returns the default string, which _ask_int converts back to int.
     assert setup_module._ask_int("Prompt", 7, min_value=0) == 7
 
 

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -442,16 +442,41 @@ def test_build_effective_config_uses_existing_and_legacy_exclusions() -> None:
     assert effective["security_linter_exclusions"] == ["tests/"]
 
 
+def test_select_sections_rerun_skip_single_edits(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    prompts_seen: list[str] = []
+
+    def fake_ask(prompt: str, default: bool = True) -> bool:
+        prompts_seen.append(prompt)
+        if prompt == "Make targeted edits to specific sections?":
+            return False
+        raise AssertionError(f"Unexpected prompt when single-edit mode declined: {prompt!r}")
+
+    monkeypatch.setattr(setup_module.Confirm, "ask", fake_ask)
+    selected = setup_module.select_sections(has_existing_config=True)
+    assert selected["languages"] is False
+    assert selected["phases"] is False
+    assert selected["security_exclusions"] is False
+    assert selected["package_managers"] is False
+    assert selected["jscpd"] is False
+    assert selected["subprocess"] is False
+    assert prompts_seen == ["Make targeted edits to specific sections?"]
+
+
 def test_select_sections_defaults_on_rerun(monkeypatch) -> None:
     setup_module = _load_setup_module()
     defaults_seen: dict[str, bool] = {}
 
     def fake_ask(prompt: str, default: bool = True) -> bool:
+        if prompt == "Make targeted edits to specific sections?":
+            defaults_seen[prompt] = default
+            return True
         defaults_seen[prompt] = default
         return default
 
     monkeypatch.setattr(setup_module.Confirm, "ask", fake_ask)
     selected = setup_module.select_sections(has_existing_config=True)
+    assert defaults_seen["Make targeted edits to specific sections?"] is False
     assert selected["languages"] is True
     assert selected["phases"] is True
     assert selected["security_exclusions"] is False
@@ -506,6 +531,67 @@ def test_main_no_sections_selected_does_not_rewrite_existing_config(tmp_path: Pa
 
     setup_module.main()
     assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_setup_hooks_installs_pre_commit_when_missing(tmp_path: Path, monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    monkeypatch.chdir(tmp_path)
+
+    hooks_dir = tmp_path / ".claude" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    (hooks_dir / "multi_linter.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / ".pre-commit-config.yaml").write_text("repos: []\n", encoding="utf-8")
+
+    monkeypatch.setattr(setup_module, "HOOKS_DIR", hooks_dir)
+    monkeypatch.setattr(setup_module.Confirm, "ask", lambda *args, **kwargs: True)
+    monkeypatch.setattr(setup_module.os, "chmod", lambda *args, **kwargs: None)
+
+    installed = {"pre_commit": False}
+    install_attempts: list[tuple[list[str], str]] = []
+    run_calls: list[tuple[list[str], bool]] = []
+
+    def fake_which(tool: str) -> str | None:
+        if tool == "pre-commit":
+            return "/usr/bin/pre-commit" if installed["pre_commit"] else None
+        if tool == "uv":
+            return "/usr/bin/uv"
+        return None
+
+    def fake_run_install(command: list[str], description: str) -> bool:
+        install_attempts.append((command, description))
+        if command == ["uv", "tool", "install", "pre-commit"]:
+            installed["pre_commit"] = True
+            return True
+        return False
+
+    def fake_subprocess_run(command: list[str], check: bool = True):
+        run_calls.append((command, check))
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(setup_module.shutil, "which", fake_which)
+    monkeypatch.setattr(setup_module, "_run_install_command", fake_run_install)
+    monkeypatch.setattr(setup_module.subprocess, "run", fake_subprocess_run)
+
+    setup_module.setup_hooks()
+
+    assert install_attempts
+    assert install_attempts[0][0] == ["uv", "tool", "install", "pre-commit"]
+    assert run_calls == [(["pre-commit", "install"], True)]
+
+
+def test_check_tools_reports_required_scope_and_status(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    printed: list[str] = []
+
+    monkeypatch.setattr(setup_module, "_ensure_local_bin_on_path", lambda *args, **kwargs: False)
+    monkeypatch.setattr(setup_module, "_guided_install_missing_tools", lambda missing: [])
+    monkeypatch.setattr(setup_module.shutil, "which", lambda tool: None)
+    monkeypatch.setattr(setup_module.console, "print", lambda msg: printed.append(str(msg)))
+
+    setup_module.check_tools()
+
+    assert any("Required tools: jaq, ruff, uv" in msg for msg in printed)
+    assert any("Required tool status:" in msg for msg in printed)
 
 
 def test_edit_list_items_add_and_remove(monkeypatch) -> None:

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -659,6 +659,23 @@ def test_ensure_pip_user_bin_on_path_prefers_higher_versions(tmp_path: Path, mon
     assert idx_13 < idx_9, "3.13 should appear before 3.9 in PATH (higher version = higher priority)"
 
 
+def test_ensure_pip_user_bin_on_path_preserves_priority_with_partial_presence(tmp_path: Path, monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    fake_base = tmp_path / "Library" / "Python"
+    for ver in ("3.9", "3.11", "3.13"):
+        (fake_base / ver / "bin").mkdir(parents=True)
+    monkeypatch.setattr(setup_module.Path, "home", lambda: tmp_path)
+    path_13 = str(fake_base / "3.13" / "bin")
+    monkeypatch.setenv("PATH", f"/usr/bin{os.pathsep}{path_13}{os.pathsep}/usr/local/bin")
+
+    assert setup_module._ensure_pip_user_bin_on_path() is True
+    path_entries = os.environ["PATH"].split(os.pathsep)
+    idx_13 = path_entries.index(str(fake_base / "3.13" / "bin"))
+    idx_11 = path_entries.index(str(fake_base / "3.11" / "bin"))
+    idx_9 = path_entries.index(str(fake_base / "3.9" / "bin"))
+    assert idx_13 < idx_11 < idx_9, f"Expected 3.13 < 3.11 < 3.9 in PATH, got indices {idx_13}, {idx_11}, {idx_9}"
+
+
 def test_ensure_pip_user_bin_on_path_noop_when_no_dirs(tmp_path: Path, monkeypatch) -> None:
     setup_module = _load_setup_module()
     monkeypatch.setattr(setup_module.Path, "home", lambda: tmp_path)

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -564,7 +564,7 @@ def test_setup_hooks_installs_pre_commit_when_missing(tmp_path: Path, monkeypatc
             return True
         return False
 
-    def fake_subprocess_run(command: list[str], check: bool = True):
+    def fake_subprocess_run(command: list[str], check: bool = True, **kwargs):
         run_calls.append((command, check))
         return types.SimpleNamespace(returncode=0)
 
@@ -579,6 +579,165 @@ def test_setup_hooks_installs_pre_commit_when_missing(tmp_path: Path, monkeypatc
     assert run_calls == [(["pre-commit", "install"], True)]
 
 
+def test_ensure_pip_user_bin_on_path_adds_macos_paths(tmp_path: Path, monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    fake_base = tmp_path / "Library" / "Python"
+    (fake_base / "3.9" / "bin").mkdir(parents=True)
+    (fake_base / "3.13" / "bin").mkdir(parents=True)
+
+    monkeypatch.setattr(setup_module.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("PATH", "/usr/bin:/usr/local/bin")
+
+    changed = setup_module._ensure_pip_user_bin_on_path()
+    assert changed is True
+    path_entries = os.environ["PATH"].split(os.pathsep)
+    assert str(fake_base / "3.13" / "bin") in path_entries
+    assert str(fake_base / "3.9" / "bin") in path_entries
+
+
+def test_install_pre_commit_resolves_macos_bin_path(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+
+    installed = {"pre_commit": False}
+    path_calls: list[str] = []
+
+    def fake_which(tool: str) -> str | None:
+        if tool == "pre-commit":
+            return "/usr/bin/pre-commit" if installed["pre_commit"] else None
+        if tool == "python3":
+            return "/usr/bin/python3"
+        return None
+
+    def fake_run_install(command: list[str], description: str) -> bool:
+        if "python3" in command[0]:
+            installed["pre_commit"] = True
+            return True
+        return False
+
+    monkeypatch.setattr(setup_module.shutil, "which", fake_which)
+    monkeypatch.setattr(setup_module, "_run_install_command", fake_run_install)
+    monkeypatch.setattr(
+        setup_module,
+        "_ensure_local_bin_on_path",
+        lambda show_hint=False: path_calls.append("local_bin") or False,
+    )
+    monkeypatch.setattr(
+        setup_module,
+        "_ensure_pip_user_bin_on_path",
+        lambda: path_calls.append("pip_user") or False,
+    )
+
+    result = setup_module._install_pre_commit()
+    assert result is True
+    assert "local_bin" in path_calls
+    assert "pip_user" in path_calls
+
+
+def test_ensure_pip_user_bin_on_path_noop_when_already_in_path(tmp_path: Path, monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    fake_base = tmp_path / "Library" / "Python"
+    bin_dir = fake_base / "3.13" / "bin"
+    bin_dir.mkdir(parents=True)
+    monkeypatch.setattr(setup_module.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}/usr/bin")
+
+    assert setup_module._ensure_pip_user_bin_on_path() is False
+
+
+def test_ensure_pip_user_bin_on_path_prefers_higher_versions(tmp_path: Path, monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    fake_base = tmp_path / "Library" / "Python"
+    for ver in ("3.9", "3.11", "3.13"):
+        (fake_base / ver / "bin").mkdir(parents=True)
+    monkeypatch.setattr(setup_module.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    setup_module._ensure_pip_user_bin_on_path()
+    path_entries = os.environ["PATH"].split(os.pathsep)
+    idx_13 = path_entries.index(str(fake_base / "3.13" / "bin"))
+    idx_9 = path_entries.index(str(fake_base / "3.9" / "bin"))
+    assert idx_13 < idx_9, "3.13 should appear before 3.9 in PATH (higher version = higher priority)"
+
+
+def test_ensure_pip_user_bin_on_path_noop_when_no_dirs(tmp_path: Path, monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    monkeypatch.setattr(setup_module.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    changed = setup_module._ensure_pip_user_bin_on_path()
+    assert changed is False
+
+
+def test_install_pre_commit_hooks_surfaces_stderr_on_failure(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    printed: list[str] = []
+    monkeypatch.setattr(setup_module.console, "print", lambda msg: printed.append(str(msg)))
+
+    import subprocess as _subprocess
+
+    error = _subprocess.CalledProcessError(1, ["pre-commit", "install"])
+    error.stderr = b"hook-install: permission denied"
+
+    def fake_run(command, *, check=False, capture_output=False):
+        raise error
+
+    monkeypatch.setattr(setup_module.subprocess, "run", fake_run)
+
+    setup_module._install_pre_commit_hooks()
+
+    assert any("pre-commit install failed" in msg for msg in printed)
+    assert any("permission denied" in msg for msg in printed)
+
+
+def test_install_pre_commit_hooks_handles_missing_binary(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    printed: list[str] = []
+    monkeypatch.setattr(setup_module.console, "print", lambda msg: printed.append(str(msg)))
+
+    def fake_run(command, *, check=False, capture_output=False):
+        raise FileNotFoundError("No such file or directory: 'pre-commit'")
+
+    monkeypatch.setattr(setup_module.subprocess, "run", fake_run)
+
+    setup_module._install_pre_commit_hooks()
+
+    assert any("pre-commit install failed" in msg for msg in printed)
+    assert any("not found" in msg for msg in printed)
+
+
+def test_install_pre_commit_returns_false_when_all_methods_fail(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+
+    def fake_which(tool: str) -> str | None:
+        if tool in ("uv", "pipx", "python3"):
+            return f"/usr/bin/{tool}"
+        return None
+
+    monkeypatch.setattr(setup_module.shutil, "which", fake_which)
+    monkeypatch.setattr(setup_module, "_run_install_command", lambda *a, **kw: False)
+    monkeypatch.setattr(setup_module, "_ensure_local_bin_on_path", lambda **kw: False)
+    monkeypatch.setattr(setup_module, "_ensure_pip_user_bin_on_path", lambda: False)
+
+    assert setup_module._install_pre_commit() is False
+
+
+def test_ensure_pre_commit_ready_shows_manual_hint_on_failure(tmp_path: Path, monkeypatch) -> None:
+    setup_module = _load_setup_module()
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".pre-commit-config.yaml").write_text("repos: []\n", encoding="utf-8")
+    printed: list[str] = []
+
+    monkeypatch.setattr(setup_module.console, "print", lambda msg: printed.append(str(msg)))
+    monkeypatch.setattr(setup_module.shutil, "which", lambda tool: None)
+    monkeypatch.setattr(setup_module.Confirm, "ask", lambda *a, **kw: True)
+    monkeypatch.setattr(setup_module, "_install_pre_commit", lambda: False)
+
+    setup_module._ensure_pre_commit_ready()
+
+    assert any("Could not install pre-commit" in msg for msg in printed)
+    assert any("uv tool install pre-commit" in msg for msg in printed)
+
+
 def test_check_tools_reports_required_scope_and_status(monkeypatch) -> None:
     setup_module = _load_setup_module()
     printed: list[str] = []
@@ -590,7 +749,10 @@ def test_check_tools_reports_required_scope_and_status(monkeypatch) -> None:
 
     setup_module.check_tools()
 
-    assert any("Required tools: jaq, ruff, uv" in msg for msg in printed)
+    tools_line = next((msg for msg in printed if "Required tools:" in msg), None)
+    assert tools_line is not None
+    for tool in setup_module.REQUIRED_TOOLS:
+        assert tool in tools_line
     assert any("Required tool status:" in msg for msg in printed)
 
 

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -633,6 +633,44 @@ def test_install_pre_commit_resolves_macos_bin_path(monkeypatch) -> None:
     assert "pip_user" in path_calls
 
 
+def test_install_pre_commit_skips_pip_user_path_for_uv(monkeypatch) -> None:
+    setup_module = _load_setup_module()
+
+    installed = {"pre_commit": False}
+    path_calls: list[str] = []
+
+    def fake_which(tool: str) -> str | None:
+        if tool == "pre-commit":
+            return "/usr/bin/pre-commit" if installed["pre_commit"] else None
+        if tool == "uv":
+            return "/usr/bin/uv"
+        return None
+
+    def fake_run_install(command: list[str], description: str) -> bool:
+        if command[0] == "uv":
+            installed["pre_commit"] = True
+            return True
+        return False
+
+    monkeypatch.setattr(setup_module.shutil, "which", fake_which)
+    monkeypatch.setattr(setup_module, "_run_install_command", fake_run_install)
+    monkeypatch.setattr(
+        setup_module,
+        "_ensure_local_bin_on_path",
+        lambda show_hint=False: path_calls.append("local_bin") or False,
+    )
+    monkeypatch.setattr(
+        setup_module,
+        "_ensure_pip_user_bin_on_path",
+        lambda: path_calls.append("pip_user") or False,
+    )
+
+    result = setup_module._install_pre_commit()
+    assert result is True
+    assert "local_bin" in path_calls
+    assert "pip_user" not in path_calls
+
+
 def test_ensure_pip_user_bin_on_path_noop_when_already_in_path(tmp_path: Path, monkeypatch) -> None:
     setup_module = _load_setup_module()
     fake_base = tmp_path / "Library" / "Python"


### PR DESCRIPTION
## Summary

- Add full config editor to setup wizard rerun flow — when an existing `config.json` is detected, users can selectively edit specific sections instead of regenerating everything
- Harden edge cases (EOF handling, empty selections, list item editing) with TDD
- Add guided pre-commit installation and hook setup during wizard run
- Fix version sort in pip-user PATH handling and FileNotFoundError in pre-commit install

## Test plan

- [x] 47 setup wizard unit tests pass
- [x] Pre-push hooks pass (ruff lint/format + hook test suite)
- [ ] Manual: run `python scripts/setup.py` with existing config — verify targeted edit flow
- [ ] Manual: run `python scripts/setup.py` without config — verify full generation still works